### PR TITLE
749 - handle index names in gh action client_payload.path

### DIFF
--- a/.github/workflows/publish-notifier.yaml
+++ b/.github/workflows/publish-notifier.yaml
@@ -20,7 +20,7 @@ jobs:
     - name: Notify upsert endpoint
       run: |
         sleep 1s
-        PAGE_PATH=$(echo "${{ github.event.client_payload.path }}" | sed 's/\.md$//g')
+        PAGE_PATH=$(echo "${{ github.event.client_payload.path }}" | awk '{sub("/index.md$", ""); sub(".md$", ""); print}')
         WEBSITE_NAME="${{ github.event.client_payload.site }}"
         URI=$(echo "${{ vars.CONNECTOR_DOMAIN }}/$WEBSITE_NAME")
         BODY='{ "paths": [ "'$PAGE_PATH'" ] }'

--- a/.github/workflows/unpublish-notifier.yaml
+++ b/.github/workflows/unpublish-notifier.yaml
@@ -21,7 +21,7 @@ jobs:
     - name: Notify delete endpoint
       run: |
         sleep 1s
-        PAGE_PATH=$(echo "${{ github.event.client_payload.path }}" | sed 's/\.md$//g')
+        PAGE_PATH=$(echo "${{ github.event.client_payload.path }}" | awk '{sub("/index.md$", ""); sub(".md$", ""); print}')
         WEBSITE_NAME="${{ github.event.client_payload.site }}"      
         URI=$(echo "${{ vars.CONNECTOR_DOMAIN }}/$WEBSITE_NAME?path=$PAGE_PATH")
         response=$(curl -s -H "x-api-key: ${{ secrets.API_KEY }}" -X DELETE "$URI")


### PR DESCRIPTION
Fix #749

URL for testing:
- https://749-search-task-4-of-4--volvotrucks-na--aemsites.hlx.page/

Other test URLs:
- Before: https://main--volvotrucks-us--volvogroup.aem.page/

Other markets:

Canada:
- Before: https://main--volvotrucks-ca--volvogroup.aem.page/
- After: https://<branch>--volvotrucks-ca--volvogroup.aem.page/

Mexico:
- Before: https://main--volvotrucks-mx--volvogroup.aem.page/
- After: https://<branch>--volvotrucks-mx--volvogroup.aem.page/
