### PR TITLE
Controls and sound configuration added to video #9

### DIFF
--- a/scripts/video-helper.js
+++ b/scripts/video-helper.js
@@ -93,15 +93,16 @@ export async function setupPlayer(url, videoContainer, config, video) {
     ...config,
     preload: config.poster && !config.autoplay ? 'none' : 'auto',
     bigPlayButton: false,
+    controls: true,
   };
 
-  const videoHasSound = (getMetadata('video-sound')).toLowerCase() === 'on';
   if (config.autoplay) {
-    videojsConfig.muted = !videoHasSound;
     videojsConfig.loop = true;
     videojsConfig.autoplay = true;
-    videojsConfig.controls = true;
   }
+
+  const videoHasSound = (getMetadata('video-sound')).toLowerCase() === 'on';
+  videojsConfig.muted = !videoHasSound;
 
   await waitForVideoJs();
 

--- a/scripts/video-helper.js
+++ b/scripts/video-helper.js
@@ -5,6 +5,7 @@ import {
   deepMerge,
   getTextLabel,
 } from './common.js';
+import { getMetadata } from './aem.js';
 
 export const VIDEO_JS_SCRIPT = '/scripts/videojs/video.min.js';
 export const VIDEO_JS_CSS = '/scripts/videojs/video-js.min.css';
@@ -94,10 +95,12 @@ export async function setupPlayer(url, videoContainer, config, video) {
     bigPlayButton: false,
   };
 
+  const videoHasSound = (getMetadata('video-sound')).toLowerCase() === 'on';
   if (config.autoplay) {
-    videojsConfig.muted = true;
+    videojsConfig.muted = !videoHasSound;
     videojsConfig.loop = true;
     videojsConfig.autoplay = true;
+    videojsConfig.controls = true;
   }
 
   await waitForVideoJs();


### PR DESCRIPTION
Fix #9

`videojsConfig` has been changed so that videos have controls and can be set with sound from the `metadata` block in the page. If there is a field with `Video sound | on` (check sharepoint) the videos in that page should play with sound.

URL for testing:
- https://9-videos-no-sound--volvotrucks-na--aemsites.hlx.page/drafts/shomps/video-metadata

Other test URLs:
- Before: https://main--volvotrucks-us--volvogroup.aem.page/drafts/shomps/video-metadata

Other markets:

Canada:
- Before: https://main--volvotrucks-ca--volvogroup.aem.page/
- After: https://9-videos-no-sound--volvotrucks-ca--volvogroup.aem.page/

Mexico:
- Before: https://main--volvotrucks-mx--volvogroup.aem.page/
- After: https://9-videos-no-sound--volvotrucks-mx--volvogroup.aem.page/
