### PR TITLE
Unified date formatting in 1 function 

### DIFF
--- a/blocks/magazine-articles/magazine-articles.js
+++ b/blocks/magazine-articles/magazine-articles.js
@@ -3,17 +3,16 @@ import {
   getOrigin,
   getTextLabel,
   createElement,
+  getDateFromTimestamp,
 } from '../../scripts/common.js';
 import {
   createList,
 } from '../../scripts/magazine-press.js';
 import {
   createOptimizedPicture,
-  getMetadata,
 } from '../../scripts/aem.js';
 import { fetchData, magazineSearchQuery } from '../../scripts/search-api.js';
 
-const locale = getMetadata('locale');
 const defaultAuthor = getTextLabel('defaultAuthor');
 const defaultReadTime = getTextLabel('defaultReadTime');
 
@@ -29,16 +28,17 @@ function buildMagazineArticle(entry) {
     publishDate,
     isDefaultImage,
   } = entry;
+
   const card = createElement('article');
   const picture = createOptimizedPicture(image, title, false, [{ width: '380', height: '214' }]);
   const pictureTag = picture.outerHTML;
-  const date = new Date((publishDate * 1000) + (new Date().getTimezoneOffset() * 60000));
+  const formattedDate = getDateFromTimestamp(publishDate);
   const categoryItem = createElement('li');
   card.innerHTML = `<a href="${path}" class="imgcover">
     ${pictureTag}
     </a>
     <div class="content">
-    <ul><li>${date.toLocaleDateString(locale)}</li>
+    <ul><li>${formattedDate}</li>
     ${(category ? categoryItem.textContent(category) : '')}</ul>
     <h3><a href="${path}">${title}</a></h3>
     <p>${description}</p>

--- a/blocks/press-releases/press-releases.js
+++ b/blocks/press-releases/press-releases.js
@@ -1,6 +1,7 @@
 import {
   getLanguagePath,
   getOrigin,
+  getDateFromTimestamp,
 } from '../../scripts/common.js';
 import {
   ffetch,
@@ -11,12 +12,10 @@ import {
 } from '../../scripts/magazine-press.js';
 import {
   createOptimizedPicture,
-  getMetadata,
   readBlockConfig,
   toClassName,
 } from '../../scripts/aem.js';
 
-const locale = getMetadata('locale');
 const stopWords = ['a', 'an', 'the', 'and', 'to', 'for', 'i', 'of', 'on', 'into'];
 
 function createPressReleaseFilterFunction(activeFilters) {
@@ -70,12 +69,12 @@ function buildPressReleaseArticle(entry) {
   const card = document.createElement('article');
   const picture = createOptimizedPicture(image, title, false, [{ width: '414' }]);
   const pictureTag = picture.outerHTML;
-  const date = new Date((publishDate * 1000) + (new Date().getTimezoneOffset() * 60000));
+  const formattedDate = getDateFromTimestamp(publishDate);
   card.innerHTML = `<a href="${path}">
     ${pictureTag}
   </a>
   <div>
-    <span class="date">${date.toLocaleDateString(locale)}</span>
+    <span class="date">${formattedDate}</span>
     <h3><a href="${path}">${title}</a></h3>
     <p>${description}</p>
   </div>`;

--- a/blocks/related-articles/related-articles.js
+++ b/blocks/related-articles/related-articles.js
@@ -1,6 +1,7 @@
 import {
   getLanguagePath,
   getOrigin,
+  getDateFromTimestamp,
 } from '../../scripts/common.js';
 import {
   ffetch,
@@ -23,15 +24,16 @@ function buildRelatedMagazineArticle(entry) {
     readingTime,
     publishDate,
   } = entry;
+
   const card = document.createElement('article');
   const picture = createOptimizedPicture(image, title, false, [{ width: '380', height: '214' }]);
   const pictureTag = picture.outerHTML;
-  const date = new Date((publishDate * 1000) + (new Date().getTimezoneOffset() * 60000));
+  const formattedDate = getDateFromTimestamp(publishDate);
   card.innerHTML = `<a href="${path}" class="imgcover">
   ${pictureTag}
   </a>
   <div class="content">
-  <ul><li>${date.toLocaleDateString()}</li></ul>
+  <ul><li>${formattedDate}</li></ul>
   <h3><a href="${path}">${title}</a></h3>
   <ul>
   <li>${author}</li>

--- a/blocks/v2-article-cards/v2-article-cards.js
+++ b/blocks/v2-article-cards/v2-article-cards.js
@@ -5,6 +5,7 @@ import {
   createElement,
   unwrapDivs,
   getTextLabel,
+  getDateFromTimestamp,
 } from '../../scripts/common.js';
 import {
   createOptimizedPicture,
@@ -28,14 +29,14 @@ const createCard = (article) => {
   const card = createElement('a', { classes: `${blockName}__article-card`, props: { href: path } });
   const picture = createOptimizedPicture(image, shortTitle, false, [{ width: '380', height: '214' }]);
   const pictureTag = picture.outerHTML;
-  const date = new Date((publishDate * 1000) + (new Date().getTimezoneOffset() * 60000));
+  const formattedDate = getDateFromTimestamp(publishDate);
   const cardContent = document.createRange().createContextualFragment(`
     <div class="${blockName}__image-wrapper">
         ${pictureTag}
     </div>
     <div class="${blockName}__texts-wrapper">
         <p class="${blockName}__card-date">
-            ${date.toLocaleDateString()}
+            ${formattedDate}
         </p>
         <h4 class="${blockName}__card-heading">
             ${shortTitle}

--- a/blocks/v2-stories-carousel/v2-stories-carousel.js
+++ b/blocks/v2-stories-carousel/v2-stories-carousel.js
@@ -8,11 +8,11 @@ import {
   createElement,
   getLanguagePath,
   getOrigin,
+  getDateFromTimestamp,
 } from '../../scripts/common.js';
 import { smoothScrollHorizontal } from '../../scripts/motion-helper.js';
 
 const blockName = 'v2-stories-carousel';
-const locale = getMetadata('locale');
 const lowLimit = 3;
 const highLimit = 7;
 
@@ -150,12 +150,13 @@ const buildStoryCard = (entry) => {
     publishDate,
     readingTime,
   } = entry;
+
   const title = originalTitle.split('|')[0].trim();
   const li = createElement('article', { classes: `${blockName}-item` });
   const picture = createOptimizedPicture(image, title, false);
   const pictureTag = picture.outerHTML;
   const readMore = (linkText || 'Read full story');
-  const date = new Date((publishDate * 1000) + (new Date().getTimezoneOffset() * 60000));
+  const formattedDate = getDateFromTimestamp(publishDate);
   const svgArrowRight = createElement('span', { classes: ['icon', 'icon-arrow-right'] });
   const cardFragment = document.createRange().createContextualFragment(`
     <a href="${path}">
@@ -166,8 +167,8 @@ const buildStoryCard = (entry) => {
       <p>${description}</p>
       <ul class="${blockName}-meta">
         <li class="${blockName}-date">
-          <time datetime="${date}" pubdate="pubdate">
-            ${date.toLocaleDateString(locale, { year: 'numeric', month: 'short', day: 'numeric' })}
+          <time datetime="${formattedDate}" pubdate="pubdate">
+            ${formattedDate}
           </time>
         </li>
         <li class="${blockName}-timetoread">

--- a/constants.json
+++ b/constants.json
@@ -144,10 +144,6 @@
     "limit": 3,
     "data": [
       {
-        "name": "DATE_LANGUAGE",
-        "value": "en-US"
-      },
-      {
         "name": "DATE_OPTIONS",
         "value": "[\"month: short\",\"day: numeric\",\"year: numeric\"]"
       },

--- a/scripts/common.js
+++ b/scripts/common.js
@@ -598,3 +598,15 @@ export const isDevHost = () => {
   const devHosts = ['localhost', 'hlx.page', 'hlx.live', 'aem.page', 'aem.live'];
   return devHosts.some((url) => window.location.host.includes(url));
 };
+
+/**
+ * Function that recieves a timestamp in seconds and returns a date
+ * in its locale's format. Defaults to US format date (MM/DD/YYYY)
+ * @param {string} timestamp The date in seconds as a string
+*/
+export const getDateFromTimestamp = (timestamp) => {
+  const locale = getMetadata('locale') || 'en-us';
+  const date = new Date((timestamp * 1000) + (new Date().getTimezoneOffset() * 60000));
+  const localeDate = Intl.DateTimeFormat(locale).format(date).replaceAll('-', '/');
+  return localeDate;
+};

--- a/templates/magazine/magazine.js
+++ b/templates/magazine/magazine.js
@@ -14,6 +14,7 @@ async function buildArticleHero(container) {
   const readtime = getMetadata('readingtime');
   const headPic = getMetadata('og:image');
   const headAlt = getMetadata('og:image:alt');
+  const locale = getMetadata('locale');
 
   const row = createElement('div', { classes: ['row', 'size-img'] });
   const headImg = createOptimizedPicture(headPic, headAlt);
@@ -23,7 +24,7 @@ async function buildArticleHero(container) {
   const calendarIcon = createElement('i', { classes: ['fa', 'fa-calendar'] });
   topDetails.append(calendarIcon);
   const pubDateSpan = createElement('span', { classes: 'date' });
-  pubDateSpan.innerHTML = pubdate;
+  pubDateSpan.innerHTML = new Intl.DateTimeFormat(locale).format(new Date(pubdate)).replaceAll('-', '/');
   topDetails.append(pubDateSpan);
 
   const timeIcon = createElement('i', { classes: ['fa', 'fa-clock-o'] });

--- a/templates/v2-magazine/v2-magazine.js
+++ b/templates/v2-magazine/v2-magazine.js
@@ -50,9 +50,9 @@ const buildMetaAuthor = () => {
 
 // Build the 2nd element of the metadata row
 const buildMetaPubDate = () => {
-  const { DATE_LANGUAGE, DATE_OPTIONS, DATE_OPTIONS_MOBILE } = MAGAZINE_CONFIGS;
+  const { DATE_OPTIONS, DATE_OPTIONS_MOBILE } = MAGAZINE_CONFIGS;
   let pubDate = getMetadata('publish-date');
-  const locale = getMetadata('locale') || DATE_LANGUAGE;
+  const locale = getMetadata('locale');
   const mobileDateOptions = extractObjectFromArray(JSON.parse(DATE_OPTIONS_MOBILE));
   const desktopDateOptions = extractObjectFromArray(JSON.parse(DATE_OPTIONS));
   const formatDateOptions = MQ.matches ? mobileDateOptions : desktopDateOptions;


### PR DESCRIPTION
Fix #17

Other URLs where the affected blocks are present:
-/news-and-stories/
-/news-and-stories/volvo-trucks-magazine/
-/news-and-stories/volvo-trucks-magazine/tackling-the-needs-of-trucking-future/

Test URLs:
- Before: https://main--volvotrucks-us--volvogroup.aem.page/drafts/shomps/v2-article-cards
- After: https://17-date-formatting--volvotrucks-us--volvogroup.aem.page/drafts/shomps/v2-article-cards

Other markets:

Canada:
- Before: https://main--volvotrucks-ca--volvogroup.aem.page/en-ca/news-and-stories/volvo-trucks-magazine/green-means-go
- After: https://17-date-formatting--volvotrucks-ca--volvogroup.aem.page/en-ca/news-and-stories/volvo-trucks-magazine/green-means-go

- Before:https://main--volvotrucks-ca--volvogroup.aem.page/en-ca/news-and-stories/
- After: https://17-date-formatting--volvotrucks-ca--volvogroup.aem.page/en-ca/news-and-stories/
