### PR TITLE
Library link changes #109

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,10 +1,8 @@
 Fix #<gh-issue-id>
 
 URL for testing:
-- https://main--volvotrucks-us--volvogroup.aem.page/
-
-Other test URLs:
-- Before: https://<branch>--volvotrucks-us--volvogroup.aem.page/
+- Before: https://main--volvotrucks-us--volvogroup.aem.page/
+- After: https://<branch>--volvotrucks-us--volvogroup.aem.page/
 
 Other markets:
 

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -12,7 +12,7 @@
       "id": "library",
       "title": "Library",
       "environments": [ "edit" ],
-      "url": "/tools/sidekick/library.html",
+      "url": "https://main--volvotrucks-us--volvogroup.aem.page/tools/sidekick/library.html",
       "includePaths": [ "**.docx**" ]
     },
     {

--- a/tools/sidekick/library.html
+++ b/tools/sidekick/library.html
@@ -20,7 +20,7 @@
   <body>
     <script
       type="module"
-      src="https://www.hlx.live/tools/sidekick/library/index.js"
+      src="https://www.aem.live/tools/sidekick/library/index.js"
     ></script>
   </body>
 </html>


### PR DESCRIPTION
Extra: Also changed a bit the PR format

Fix #109

URL for testing:
- Before: https://main--volvotrucks-us--volvogroup.aem.page/
- After: https://109-library-fix--volvotrucks-us--volvogroup.aem.page/

Other markets:

Canada:
- Before: https://main--volvotrucks-ca--volvogroup.aem.page/
- After: https://109-library-fix--volvotrucks-ca--volvogroup.aem.page/

Mexico:
- Before: https://main--volvotrucks-mx--volvogroup.aem.page/
- After: https://109-library-fix--volvotrucks-mx--volvogroup.aem.page/
