### PR TITLE
FE magazine article search #33

### DIFF
--- a/blocks/v2-article-search/v2-article-search.css
+++ b/blocks/v2-article-search/v2-article-search.css
@@ -5,6 +5,8 @@
 
 .v2-article-search-wrapper {
   background-color: var(--background-color);
+  position: sticky;
+  top: 0;
 }
 
 .v2-article-search.block {

--- a/blocks/v2-article-search/v2-article-search.css
+++ b/blocks/v2-article-search/v2-article-search.css
@@ -14,6 +14,16 @@
   margin: 0 auto;
 }
 
+.block.v2-article-search--black {
+  background-color: var(--c-black);
+  color: var(--c-white);
+}
+
+.block.v2-article-search--gray {
+  background-color: var(--c-grey-1);
+  color: var(--c-grey-4);
+}
+
 .v2-article-search__fieldset {
   padding: 10px 20px;
   border: none;
@@ -68,6 +78,17 @@ ul.v2-article-search__filter-list {
   align-content: baseline;
 }
 
+.block.v2-article-search--black ul.v2-article-search__filter-list {
+  background-color: var(--c-black);
+  color: var(--c-white);
+  box-shadow: 0 4px 8px #fff7;
+}
+
+.block.v2-article-search--gray ul.v2-article-search__filter-list {
+  background-color: var(--c-grey-1);
+  color: var(--c-grey-4);
+}
+
 .v2-article-search__filter-list-wrapper--open {
   display: flex;
 }
@@ -88,9 +109,27 @@ a.v2-article-search__filter-link {
   color: var(--button-primary-bg);
 }
 
+.block.v2-article-search--gray a.v2-article-search__filter-link,
+.block.v2-article-search--black a.v2-article-search__filter-link {
+  color: inherit;
+  outline-color: inherit;
+}
+
 a.v2-article-search__filter-link--active,
 a.v2-article-search__filter-link:hover {
   background-color: var(--button-primary-bg);
+  color: var(--c-white);
+}
+
+.block.v2-article-search--black a.v2-article-search__filter-link--active,
+.block.v2-article-search--black a.v2-article-search__filter-link:hover {
+  background-color: var(--c-white);
+  color: var(--c-black);
+}
+
+.block.v2-article-search--gray a.v2-article-search__filter-link--active,
+.block.v2-article-search--gray a.v2-article-search__filter-link:hover {
+  background-color: var(--c-grey-4);
   color: var(--c-white);
 }
 
@@ -163,6 +202,12 @@ a.v2-article-search__filter-link:hover {
 
 .v2-article-search__search-input--expanded .v2-article-search__filter-dropdown {
   display: none;
+}
+
+.block.v2-article-search--black .v2-article-search__input-label,
+.block.v2-article-search--black .v2-article-search__fieldset,
+.block.v2-article-search--black .v2-article-search__filter-dropdown {
+  color: inherit;
 }
 
 .v2-article-search__clear-button {

--- a/blocks/v2-article-search/v2-article-search.css
+++ b/blocks/v2-article-search/v2-article-search.css
@@ -14,6 +14,7 @@
   display: flex;
   justify-content: space-between;
   color: var(--c-grey-4);
+  height: 54px; /* Check if this is needed when padding/margin are adjusted */
 }
 
 .v2-article-search__filter-container {
@@ -85,11 +86,20 @@ a.v2-article-search__filter-link:hover {
 }
 
 .block .v2-article-search__filter-input input {
-  margin: auto;
+  margin: 0;
   padding: 0;
   background-color: var(--background-color);
   border: none;
   display: none;
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 20.8px;
+  letter-spacing: 0.5px;
+  color: var(--c-main-black);
+}
+
+.v2-article-search__filter-input input::placeholder {
+  color: var(--c-grey-3);
 }
 
 .v2-article-search__filter-input .icon {
@@ -99,6 +109,7 @@ a.v2-article-search__filter-link:hover {
 
 .v2-article-search__filter-input .icon-close {
   display: none;
+  margin-left: auto;
 }
 
 .v2-article-search__filter-dropdown--open ~ .v2-article-search__filter-input .icon-search-icon {
@@ -114,6 +125,66 @@ a.v2-article-search__filter-link:hover {
   display: none;
 }
 
+.v2-article-search__search-input--expanded .v2-article-search__fieldset {
+  justify-content: flex-start;
+}
+
+.v2-article-search__search-input--expanded .v2-article-search__filter-input {
+  width: 100%;
+  transition: width 0.3s ease;
+}
+
+.v2-article-search__search-input--expanded .v2-article-search__filter-input input {
+  display: block;
+  width: 100%;
+  flex-grow: 1;
+}
+
+.v2-article-search__search-input--expanded .v2-article-search__filter-input input:focus-visible {
+  outline: none;
+}
+
+.v2-article-search__search-input--expanded .v2-article-search__filter-input .icon-close {
+  display: block;
+}
+
+.v2-article-search__search-input--expanded .v2-article-search__filter-dropdown {
+  display: none;
+}
+
+.v2-article-search__filter-input {
+  align-items: center;
+}
+
+.v2-article-search__clear-button {
+  display: none;
+  background: none;
+  border: none;
+  color: var(--c-grey-4);
+  text-decoration: underline;
+  margin-left: auto;
+  padding-left: 16px;
+  padding-right: 8px;
+}
+
+.v2-article-search__clear-button::after {
+  content: "";
+  width: 1px;
+  height: 16px;
+  background-color: var(--c-grey-300);
+  margin-left: 16px;
+}
+
+.v2-article-search__clear-button.active {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.v2-article-search__clear-button.active + .icon-close {
+  margin-left: 0;
+}
+
 @media (min-width: 768px) {
   .v2-article-search__filter-dropdown--open {
     visibility: visible;
@@ -124,7 +195,8 @@ a.v2-article-search__filter-link:hover {
     font-family: var(--font-family-body);
   }
 
-  .v2-article-search__filter-dropdown--open ~ .v2-article-search__filter-input label.v2-article-search__input-label {
+  .v2-article-search__filter-dropdown--open ~ .v2-article-search__filter-input .v2-article-search__input-label,
+  .v2-article-search__search-input--expanded .v2-article-search__filter-input .v2-article-search__input-label {
     display: none;
   }
 

--- a/blocks/v2-article-search/v2-article-search.css
+++ b/blocks/v2-article-search/v2-article-search.css
@@ -62,6 +62,8 @@ ul.v2-article-search__filter-list {
   background-color: var(--background-color);
   padding: 10px 20px;
   box-shadow: 0 4px 8px #0003;
+  height: 100%;
+  align-content: baseline;
 }
 
 .v2-article-search__filter-list-wrapper--open {

--- a/blocks/v2-article-search/v2-article-search.css
+++ b/blocks/v2-article-search/v2-article-search.css
@@ -134,6 +134,6 @@ a.v2-article-search__filter-link:hover {
 
   .v2-article-search__filter-list-wrapper--open .v2-article-search__filter-list {
     width: 100%;
-    padding: 10px 20px 20px;
+    padding: 10px 20px 100px;
   }
 }

--- a/blocks/v2-article-search/v2-article-search.css
+++ b/blocks/v2-article-search/v2-article-search.css
@@ -1,5 +1,10 @@
 :root {
   --icon-size: 24px;
+  --bullets-gap: 16px 8px;
+}
+
+.v2-article-search-wrapper {
+  background-color: var(--background-color);
 }
 
 .v2-article-search.block {
@@ -9,7 +14,6 @@
 
 .v2-article-search__fieldset {
   padding: 10px 20px;
-  margin: 0 0 10px;
   border: none;
   display: flex;
   justify-content: space-between;
@@ -53,7 +57,7 @@
 ul.v2-article-search__filter-list {
   display: flex;
   flex-wrap: wrap;
-  gap: 16px 8px;
+  gap: var(--bullets-gap);
   position: absolute;
   background-color: var(--background-color);
   padding: 10px 20px;
@@ -129,6 +133,10 @@ a.v2-article-search__filter-link:hover {
   justify-content: flex-start;
 }
 
+.v2-article-search__filter-input {
+  align-items: center;
+}
+
 .v2-article-search__search-input--expanded .v2-article-search__filter-input {
   width: 100%;
   transition: width 0.3s ease;
@@ -150,10 +158,6 @@ a.v2-article-search__filter-link:hover {
 
 .v2-article-search__search-input--expanded .v2-article-search__filter-dropdown {
   display: none;
-}
-
-.v2-article-search__filter-input {
-  align-items: center;
 }
 
 .v2-article-search__clear-button {
@@ -200,12 +204,18 @@ a.v2-article-search__filter-link:hover {
     display: none;
   }
 
+  ul.v2-article-search__filter-list {
+    --bullets-gap: 24px 16px;;
+  }
+
   .v2-article-search__filter-list-wrapper--open {
     height: auto;
   }
 
   .v2-article-search__filter-list-wrapper--open .v2-article-search__filter-list {
     width: 100%;
-    padding: 10px 20px 100px;
+    padding: 24px 16px;
+    height: 238px;
+    align-content: baseline;
   }
 }

--- a/blocks/v2-article-search/v2-article-search.css
+++ b/blocks/v2-article-search/v2-article-search.css
@@ -1,14 +1,19 @@
+:root {
+  --icon-size: 24px;
+}
+
 .v2-article-search.block {
   width: var(--wrapper-width);
   margin: 0 auto;
 }
 
 .v2-article-search__fieldset {
-  padding: 1rem 2rem;
-  margin: 0 0 1rem;
+  padding: 10px 20px;
+  margin: 0 0 10px;
   border: none;
   display: flex;
   justify-content: space-between;
+  color: var(--c-grey-4);
 }
 
 .v2-article-search__filter-container {
@@ -28,7 +33,11 @@
 }
 
 .v2-article-search__filter-dropdown-icon {
-  font-size: var(--f-body-font-size);
+  font-size: var(--icon-size);
+}
+
+.v2-article-search__filter-dropdown--open {
+  visibility: hidden;
 }
 
 .v2-article-search__filter-dropdown--open .v2-article-search__filter-dropdown-icon {
@@ -43,7 +52,7 @@
 ul.v2-article-search__filter-list {
   display: flex;
   flex-wrap: wrap;
-  gap: .5rem;
+  gap: 16px 8px;
   position: absolute;
   background-color: var(--background-color);
   padding: 10px 20px;
@@ -80,4 +89,51 @@ a.v2-article-search__filter-link:hover {
   padding: 0;
   background-color: var(--background-color);
   border: none;
+  display: none;
+}
+
+.v2-article-search__filter-input .icon {
+  font-size: var(--icon-size);
+  cursor: pointer;
+}
+
+.v2-article-search__filter-input .icon-close {
+  display: none;
+}
+
+.v2-article-search__filter-dropdown--open ~ .v2-article-search__filter-input .icon-search-icon {
+  display: none;
+}
+
+.v2-article-search__filter-dropdown--open ~ .v2-article-search__filter-input .icon-close {
+  display: block;
+  max-height: var(--icon-size);
+}
+
+.v2-article-search__input-label {
+  display: none;
+}
+
+@media (min-width: 768px) {
+  .v2-article-search__filter-dropdown--open {
+    visibility: visible;
+  }
+
+  .v2-article-search__filter-input label.v2-article-search__input-label {
+    display: block;
+    font-family: var(--font-family-body);
+  }
+
+  .v2-article-search__filter-dropdown--open ~ .v2-article-search__filter-input label.v2-article-search__input-label {
+    display: none;
+  }
+
+  .v2-article-search__filter-list-wrapper--open {
+    height: auto;
+  }
+
+  .v2-article-search__filter-list-wrapper--open .v2-article-search__filter-list {
+    width: 100%;
+    padding: 10px 20px 20px;
+  }
 }

--- a/blocks/v2-article-search/v2-article-search.css
+++ b/blocks/v2-article-search/v2-article-search.css
@@ -61,6 +61,7 @@ ul.v2-article-search__filter-list {
   position: absolute;
   background-color: var(--background-color);
   padding: 10px 20px;
+  box-shadow: 0 4px 8px #0003;
 }
 
 .v2-article-search__filter-list-wrapper--open {

--- a/blocks/v2-article-search/v2-article-search.css
+++ b/blocks/v2-article-search/v2-article-search.css
@@ -1,0 +1,83 @@
+.v2-article-search.block {
+  width: var(--wrapper-width);
+  margin: 0 auto;
+}
+
+.v2-article-search__fieldset {
+  padding: 1rem 2rem;
+  margin: 0 0 1rem;
+  border: none;
+  display: flex;
+  justify-content: space-between;
+}
+
+.v2-article-search__filter-container {
+  position: relative;
+}
+
+.v2-article-search__filter-input,
+.v2-article-search__filter-dropdown {
+  display: flex;
+  gap: .3rem;
+  align-items: center;
+}
+
+.v2-article-search__filter-dropdown{
+  font-size: var(--f-button-font-size);
+  cursor: pointer;
+}
+
+.v2-article-search__filter-dropdown-icon {
+  font-size: var(--f-body-font-size);
+}
+
+.v2-article-search__filter-dropdown--open .v2-article-search__filter-dropdown-icon {
+  transform: rotate(180deg);
+}
+
+.v2-article-search__filter-list-wrapper {
+  height: 100vh;
+  display: none;
+}
+
+ul.v2-article-search__filter-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .5rem;
+  position: absolute;
+  background-color: var(--background-color);
+  padding: 10px 20px;
+}
+
+.v2-article-search__filter-list-wrapper--open {
+  display: flex;
+}
+
+.v2-article-search__filter-item {
+  list-style: none;
+  display: inline-flex;
+  flex-wrap: wrap;
+}
+
+a.v2-article-search__filter-link {
+  height: 32px;
+  padding: 10px 20px;
+  border-radius: 99px;
+  outline: 1px solid var(--button-primary-bg);
+  font-size: var(--f-button-font-size);
+  line-height: 1;
+  color: var(--button-primary-bg);
+}
+
+a.v2-article-search__filter-link--active,
+a.v2-article-search__filter-link:hover {
+  background-color: var(--button-primary-bg);
+  color: var(--c-white);
+}
+
+.block .v2-article-search__filter-input input {
+  margin: auto;
+  padding: 0;
+  background-color: var(--background-color);
+  border: none;
+}

--- a/blocks/v2-article-search/v2-article-search.js
+++ b/blocks/v2-article-search/v2-article-search.js
@@ -1,5 +1,6 @@
 import {
   decorateIcons, getPlaceholders, getTextLabel, getLocale,
+  variantsClassesToBEM,
 } from '../../scripts/common.js';
 import { topicSearchQuery, fetchData, TENANT } from '../../scripts/search-api.js';
 
@@ -12,6 +13,7 @@ const dropdownOpen = `${blockName}__filter-dropdown--open`;
 const filterListOpen = `${blockName}__filter-list-wrapper--open`;
 const filterActive = `${blockName}__filter-link--active`;
 const searchInputExpanded = `${blockName}__search-input--expanded`;
+const blockVariants = ['black', 'gray'];
 
 await getPlaceholders();
 const filterDefault = getTextLabel('filterDefault');
@@ -250,6 +252,7 @@ export default async function decorate(block) {
       if ([blockStatus, sectionStatus].every((status) => status === 'loaded')) {
         const filter = buildFilterElement();
         const filterList = await buildFilterList();
+        variantsClassesToBEM(block.classList, blockVariants, blockName);
         filter.querySelector(`.${blockName}__filter-list-wrapper`).append(filterList);
         block.prepend(filter);
         addDropdownHandler(block.querySelector(`.${blockName}__filter-dropdown`));

--- a/blocks/v2-article-search/v2-article-search.js
+++ b/blocks/v2-article-search/v2-article-search.js
@@ -1,0 +1,109 @@
+import { decorateIcons, getPlaceholders, getTextLabel } from '../../scripts/common.js';
+
+const blockName = 'v2-article-search';
+const wrapperClass = `${blockName}-wrapper`;
+const containerClass = `${blockName}-container`;
+const filterContainerClass = `${blockName}__filter-container`;
+const dropdownClass = `${blockName}__filter-dropdown`;
+const dropdownOpen = `${blockName}__filter-dropdown--open`;
+const filterListOpen = `${blockName}__filter-list-wrapper--open`;
+const filterActive = `${blockName}__filter-link--active`;
+
+await getPlaceholders();
+const filterDefault = getTextLabel('filterDefault');
+const searchPlaceholder = getTextLabel('searchPlaceholder');
+
+const buildFilterElement = () => document.createRange().createContextualFragment(`
+  <div class="${blockName}__filter-container">
+    <form class="${blockName}__filter">
+      <fieldset class="${blockName}__fieldset">
+        <div class="${blockName}__filter-dropdown">
+          ${filterDefault} <span class="${blockName}__filter-dropdown-icon">
+            <span class="icon icon-chevron-down"></span>
+          </span>
+        </div>
+        <div class="${blockName}__filter-input">
+          <span class="icon icon-search-icon"></span>
+          <input type="text" placeholder="${searchPlaceholder}" />
+        </div>
+      </fieldset>
+    </form>
+    <div class="${blockName}__filter-list-wrapper"></div>
+  </div>
+`);
+
+// FIXME: added fake items to simulate the filter list
+// TODO: (remove the fake items to be added dynamically)
+const buildFilterList = () => document.createRange().createContextualFragment(`
+  <ul class="${blockName}__filter-list">
+    <li class="${blockName}__filter-item">
+      <a href="#" class="${blockName}__filter-link">Filter 1</a>
+    </li>
+    <li class="${blockName}__filter-item">
+      <a href="#" class="${blockName}__filter-link">Filter very long text</a>
+    </li>
+    <li class="${blockName}__filter-item">
+      <a href="#" class="${blockName}__filter-link">Filter short</a>
+    </li>
+  </ul>
+`);
+
+const addDropdownListener = (filter) => {
+  filter.addEventListener('click', (e) => {
+    const dropdown = e.target.tagName === 'svg'
+      ? e.target.closest(`.${dropdownClass}`) : e.target;
+    const filterContainer = dropdown.closest(`.${filterContainerClass}`);
+    const filterList = filterContainer.querySelector(`.${blockName}__filter-list-wrapper`);
+    dropdown.classList.toggle(dropdownOpen);
+    filterList.classList.toggle(filterListOpen);
+  });
+};
+
+const addFilterListListener = (itemLink) => {
+  itemLink.addEventListener('click', (e) => {
+    if (e.target.tagName !== 'A') return;
+    const filterList = e.target.closest(`.${blockName}__filter-list`);
+    const otherItems = [...filterList.querySelectorAll(`.${blockName}__filter-link`)]
+      .filter((item) => item !== e.target);
+    otherItems.forEach((item) => item.classList.remove(filterActive));
+    e.target.classList.toggle(filterActive);
+    // do the query to update based on the selected filters
+    // TODO: submit the form to update the article
+
+    // close the dropdown
+    const filterContainer = filterList.closest(`.${filterContainerClass}`);
+    const dropdown = filterContainer.querySelector(`.${dropdownClass}`);
+    const filterListWrapper = filterContainer.querySelector(`.${blockName}__filter-list-wrapper`);
+    dropdown.classList.remove(dropdownOpen);
+    filterListWrapper.classList.remove(filterListOpen);
+  });
+};
+
+export default async function decorate(block) {
+  const main = block.closest('main');
+  const wrapper = block.closest(`.${wrapperClass}`);
+  const section = block.closest(`.${containerClass}`);
+  const observer = new MutationObserver((mutations) => {
+    mutations.forEach((mutation) => {
+      if (mutation.type !== 'childList') return;
+      const blockStatus = block.getAttribute('data-block-status');
+      const sectionStatus = section.getAttribute('data-section-status');
+      if ([blockStatus, sectionStatus].every((status) => status === 'loaded')) {
+        const filter = buildFilterElement();
+        const filterList = buildFilterList();
+        filter.querySelector(`.${blockName}__filter-list-wrapper`).append(filterList);
+        block.prepend(filter);
+        addDropdownListener(block.querySelector(`.${blockName}__filter-dropdown`));
+        addFilterListListener(block.querySelector(`.${blockName}__filter-list`));
+        decorateIcons(block);
+        section.classList.remove(containerClass);
+        main.prepend(wrapper);
+        observer.disconnect();
+      }
+    });
+  });
+
+  observer.observe(main, {
+    childList: true,
+  });
+}

--- a/blocks/v2-article-search/v2-article-search.js
+++ b/blocks/v2-article-search/v2-article-search.js
@@ -96,7 +96,7 @@ const buildBulletList = (allTopics) => Object.keys(allTopics).map((key) => {
     currentURL.search = magazineParam;
     currentURL.searchParams.set(key, param);
     return `<li class="${blockName}__filter-item">
-      <a href="${currentURL.href.replace('#', '')}" target="_blank"
+      <a href="${currentURL.href.replace('#', '')}"
         class="${blockName}__filter-link">${item}</a>
     </li>`;
   }).join('');

--- a/blocks/v2-article-search/v2-article-search.js
+++ b/blocks/v2-article-search/v2-article-search.js
@@ -13,6 +13,9 @@ await getPlaceholders();
 const filterDefault = getTextLabel('filterDefault');
 const searchPlaceholder = getTextLabel('searchPlaceholder');
 
+// const MQDesktop = window.matchMedia('(min-width: 1200px)');
+// const MQtablet = window.matchMedia('(min-width: 768px)');
+
 const buildFilterElement = () => document.createRange().createContextualFragment(`
   <div class="${blockName}__filter-container">
     <form class="${blockName}__filter">
@@ -24,7 +27,9 @@ const buildFilterElement = () => document.createRange().createContextualFragment
         </div>
         <div class="${blockName}__filter-input">
           <span class="icon icon-search-icon"></span>
-          <input type="text" placeholder="${searchPlaceholder}" />
+          <input type="text" id="search" name="search" placeholder="${searchPlaceholder}" />
+          <label for="search" class="${blockName}__input-label">${searchPlaceholder}</label>
+          <span class="icon icon-close"></span>
         </div>
       </fieldset>
     </form>
@@ -43,12 +48,30 @@ const buildFilterList = () => document.createRange().createContextualFragment(`
       <a href="#" class="${blockName}__filter-link">Filter very long text</a>
     </li>
     <li class="${blockName}__filter-item">
+      <a href="#" class="${blockName}__filter-link">Filter very long text</a>
+    </li>
+    <li class="${blockName}__filter-item">
+      <a href="#" class="${blockName}__filter-link">Filter very long text</a>
+    </li>
+    <li class="${blockName}__filter-item">
+      <a href="#" class="${blockName}__filter-link">Filter very long text</a>
+    </li>
+    <li class="${blockName}__filter-item">
+      <a href="#" class="${blockName}__filter-link">Filter very long text</a>
+    </li>
+    <li class="${blockName}__filter-item">
+      <a href="#" class="${blockName}__filter-link">Filter very long text</a>
+    </li>
+    <li class="${blockName}__filter-item">
+      <a href="#" class="${blockName}__filter-link">Filter very long text</a>
+    </li>
+    <li class="${blockName}__filter-item">
       <a href="#" class="${blockName}__filter-link">Filter short</a>
     </li>
   </ul>
 `);
 
-const addDropdownListener = (filter) => {
+const addDropdownHandler = (filter) => {
   filter.addEventListener('click', (e) => {
     const dropdown = e.target.tagName === 'svg'
       ? e.target.closest(`.${dropdownClass}`) : e.target;
@@ -59,7 +82,7 @@ const addDropdownListener = (filter) => {
   });
 };
 
-const addFilterListListener = (itemLink) => {
+const addFilterListHandler = (itemLink) => {
   itemLink.addEventListener('click', (e) => {
     if (e.target.tagName !== 'A') return;
     const filterList = e.target.closest(`.${blockName}__filter-list`);
@@ -79,6 +102,17 @@ const addFilterListListener = (itemLink) => {
   });
 };
 
+// TODO: check if the close button has to close the filter list or the search input
+const addCloseHandler = (closeIcon) => {
+  closeIcon.addEventListener('click', (e) => {
+    const filterContainer = e.target.closest(`.${filterContainerClass}`);
+    const filterList = filterContainer.querySelector(`.${blockName}__filter-list-wrapper`);
+    const dropdown = filterContainer.querySelector(`.${dropdownClass}`);
+    filterList.classList.remove(filterListOpen);
+    dropdown.classList.remove(dropdownOpen);
+  });
+};
+
 export default async function decorate(block) {
   const main = block.closest('main');
   const wrapper = block.closest(`.${wrapperClass}`);
@@ -93,8 +127,9 @@ export default async function decorate(block) {
         const filterList = buildFilterList();
         filter.querySelector(`.${blockName}__filter-list-wrapper`).append(filterList);
         block.prepend(filter);
-        addDropdownListener(block.querySelector(`.${blockName}__filter-dropdown`));
-        addFilterListListener(block.querySelector(`.${blockName}__filter-list`));
+        addDropdownHandler(block.querySelector(`.${blockName}__filter-dropdown`));
+        addFilterListHandler(block.querySelector(`.${blockName}__filter-list`));
+        addCloseHandler(block.querySelector('.icon-close'));
         decorateIcons(block);
         section.classList.remove(containerClass);
         main.prepend(wrapper);

--- a/blocks/v2-article-search/v2-article-search.js
+++ b/blocks/v2-article-search/v2-article-search.js
@@ -58,11 +58,11 @@ const getTopics = async (props = {}) => {
     }
 
     const [trucks, topics, articles] = querySuccess.facets;
-    return {
-      truck: [...new Set(trucks.items.map((item) => item.value.trim()))],
-      topic: [...new Set(topics.items.map((item) => item.value.trim()))],
-      category: [...new Set(articles.items.map((item) => item.value.trim()))],
-    };
+    return [
+      ...new Set(trucks.items.map((item) => ({ key: 'truck', value: item.value.trim() }))),
+      ...new Set(topics.items.map((item) => ({ key: 'topic', value: item.value.trim() }))),
+      ...new Set(articles.items.map((item) => ({ key: 'category', value: item.value.trim() }))),
+    ].sort((a, b) => a.value.localeCompare(b.value));
   } catch (error) {
     console.error('Error fetching data:', error);
     throw error;
@@ -91,17 +91,14 @@ const buildFilterElement = () => document.createRange().createContextualFragment
   </div>
 `);
 
-const buildBulletList = (allTopics) => Object.keys(allTopics).map((key) => {
-  const items = allTopics[key];
-  return items.map((item) => {
-    const param = item.toLowerCase().replace(/\s/g, '-');
-    currentURL.search = magazineParam;
-    currentURL.searchParams.set(key, param);
-    return `<li class="${blockName}__filter-item">
-      <a href="${currentURL.href.replace('#', '')}"
-        class="${blockName}__filter-link">${item}</a>
-    </li>`;
-  }).join('');
+const buildBulletList = (allTopics) => allTopics.map((item) => {
+  const param = item.value.toLowerCase().replace(/\s/g, '-');
+  currentURL.search = magazineParam;
+  currentURL.searchParams.set(item.key, param);
+  return `<li class="${blockName}__filter-item">
+    <a href="${currentURL.href.replace('#', '')}"
+      class="${blockName}__filter-link">${item.value}</a>
+  </li>`;
 }).join('');
 
 const buildFilterList = async () => {

--- a/blocks/v2-article-search/v2-article-search.js
+++ b/blocks/v2-article-search/v2-article-search.js
@@ -91,13 +91,20 @@ const buildFilterElement = () => document.createRange().createContextualFragment
   </div>
 `);
 
+// Capitalize the first letter of each word
+const formatValue = (item) => {
+  const { key, value } = item;
+  return key === 'truck'
+    ? value.toUpperCase() : value.replace(/\b\w/g, (char) => char.toUpperCase());
+};
+
 const buildBulletList = (allTopics) => allTopics.map((item) => {
   const param = item.value.toLowerCase().replace(/\s/g, '-');
   currentURL.search = magazineParam;
   currentURL.searchParams.set(item.key, param);
   return `<li class="${blockName}__filter-item">
     <a href="${currentURL.href.replace('#', '')}"
-      class="${blockName}__filter-link">${item.value}</a>
+      class="${blockName}__filter-link">${formatValue(item)}</a>
   </li>`;
 }).join('');
 

--- a/placeholder.json
+++ b/placeholder.json
@@ -350,6 +350,14 @@
     {
       "Key": "paginationNextPageAriaLabel",
       "Text": "next page"
+    },
+    {
+      "Key": "filterDefault",
+      "Text": "All Topics"
+    },
+    {
+      "Key": "searchPlaceholder",
+      "Text": "Search magazine"
     }
   ],
   ":type": "sheet"

--- a/scripts/search-api.js
+++ b/scripts/search-api.js
@@ -116,3 +116,37 @@ $category: [String], $facets: [EdsFieldEnum], $article: ArticleFilter, $sort: Ed
   }
 }
 `;
+
+export const topicSearchQuery = () => `
+  query Edsrecommend($tenant: String!, $language: EdsLocaleEnum!, $limit: Int, $offset: Int, $category: String, $article: ArticleFilter, $sort: EdsSortOptionsEnum, $facets: [EdsFieldEnum]) {
+    edsrecommend(tenant: $tenant, language: $language, limit: $limit, offset: $offset, category: $category, article: $article, sort: $sort, facets: $facets) {
+      count
+      items {
+        uuid
+        score
+        metadata {
+          title
+          description
+          url
+          language
+          lastModified
+          publishDate
+          image
+          article {
+            author
+            topic
+            truck
+            readTime
+          }
+        }
+      }
+      facets {
+        field
+        items {
+          value
+          count
+        }
+      }
+    }
+  }
+`;


### PR DESCRIPTION
Fix #33

This block can be added above a magazine article and this will open in a new tab on the magazine's main page with the URL updated with the topic selected from the dropdown `All Topics` list and the search input also opens with the search term.

if the user goes back to the article page, the dropdown keeps the bullet selected (unless the tab is closed) and if something is searched, the input is reset

2 variants can be added: _black_ and _gray_, if both are used together, gray overwrite the black variant

URL for testing:
- https://main--volvotrucks-us--volvogroup.aem.page/drafts/jlledo/magazine/magazine-article-demo
- Before: https://33-fe-magazine-article--volvotrucks-us--volvogroup.aem.page/drafts/jlledo/magazine/magazine-article-demo
