### PR TITLE
add import Noto font to the head & minor font adjustments #153

### DIFF
--- a/head.html
+++ b/head.html
@@ -6,3 +6,6 @@
 <link rel="preload" href="/constants.json" as="fetch" type="application/json" crossorigin="anonymous"/>
 <link rel="stylesheet" href="/styles/styles.css" />
 <link rel="icon" href="data:," />
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wdth,wght@0,62.5..100,100..900;1,62.5..100,100..900&display=swap" rel="stylesheet">

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -7,8 +7,7 @@
 */
 @font-face {
   font-family: 'VolvoNovum Fallback';
-  src: local('Noto Sans'),
-  url('https://fonts.gstatic.com/s/notosans/v27/o-0IIpQlx3QUlC5A4PNr5TRA.woff2') format('woff2');
+  src: local('Noto Sans');
   size-adjust: 102%;
   ascent-override: 95%;
   descent-override: normal;
@@ -17,8 +16,7 @@
 
 @font-face {
   font-family: 'VolvoNovum-Medium Fallback';
-  src: local('Noto Sans'),
-  url('https://fonts.gstatic.com/s/notosans/v27/o-0IIpQlx3QUlC5A4PNr5TRA.woff2') format('woff2');
+  src: local('Noto Sans');
   size-adjust: 103%;
   ascent-override: 92%;
   descent-override: normal;
@@ -28,8 +26,7 @@
 /* previous fallback font was Arial Narrow */
 @font-face {
   font-family: 'VolvoBroadProDigital Fallback';
-  src: local('Noto Sans'),
-  url('https://fonts.gstatic.com/s/notosans/v27/o-0IIpQlx3QUlC5A4PNr5TRA.woff2') format('woff2');
+  src: local('Noto Sans');
   font-style: normal;
   font-weight: 400;
   ascent-override: 100%;
@@ -42,8 +39,7 @@
   font-family: 'fontawesome Fallback';
   font-style: normal;
   font-weight: 400;
-  src: local('Noto Sans'),
-  url('https://fonts.gstatic.com/s/notosans/v27/o-0IIpQlx3QUlC5A4PNr5TRA.woff2') format('woff2');
+  src: local('Noto Sans');
   ascent-override: 93.75%;
   descent-override: 6.25%;
   line-gap-override: 0%;
@@ -53,9 +49,9 @@
 :root {
   /* fonts */
   --ff-fallback-default: 'Noto Sans', sans-serif;
-  --ff-volvo-novum-medium: 'VolvoNovum-Medium', 'VolvoNovum-Medium Fallback', sans-serif;
-  --ff-volvo-novum: 'VolvoNovum', 'VolvoNovum Fallback', sans-serif;
-  --ff-volvo-broadprodigital: 'VolvoBroadProDigital', 'VolvoBroadProDigital Fallback', sans-serif;
+  --ff-volvo-novum-medium: 'VolvoNovum-Medium', 'VolvoNovum-Medium Fallback', var(--ff-fallback-default);
+  --ff-volvo-novum: 'VolvoNovum', 'VolvoNovum Fallback', var(--ff-fallback-default);
+  --ff-volvo-broadprodigital: 'VolvoBroadProDigital', 'VolvoBroadProDigital Fallback', var(--ff-fallback-default);
   --ff-fontawesome: 'fontawesome', 'fontawesome Fallback';
   --font-family-body: var(--ff-volvo-novum);
   --font-family-heading: var(--ff-volvo-novum-medium);


### PR DESCRIPTION
This fix removes a minor bug related to how the Noto font is imported. now is added to the `head.html`

Fix #153

URL for testing:
- Before: https://main--volvotrucks-us--volvogroup.aem.page/
- After: https://153-bug-fix-fonts-loading--volvotrucks-us--volvogroup.aem.page/