### PR TITLE
add a z-index for all viewports #160

### DIFF
--- a/blocks/v2-article-search/v2-article-search.css
+++ b/blocks/v2-article-search/v2-article-search.css
@@ -9,6 +9,7 @@
   position: sticky;
   top: 0;
   height: 54px;
+  z-index: 1;
 }
 
 .section.v2-article-search-container .v2-article-search-wrapper {
@@ -258,10 +259,6 @@ a.v2-article-search__filter-link:hover {
 }
 
 @media (min-width: 768px) {
-  .v2-article-search-wrapper {
-    z-index: 1;
-  }
-
   .v2-article-search__filter-dropdown--open {
     visibility: visible;
   }


### PR DESCRIPTION
# Fix

add for all viewports a z-index to push to front the topics dropdown, not only in desktop

Fix #160

URL for testing:
- Before: https://main--volvotrucks-us--volvogroup.aem.page/news-and-stories/volvo-trucks-stories/
- After: https://160-magazine-filters-drop-down--volvotrucks-us--volvogroup.aem.page/news-and-stories/volvo-trucks-stories/
