### PR TITLE
Bug: Blurry Images on Volvo Trucks Stories Overview Page #159

### DIFF
--- a/blocks/v2-article-cards/v2-article-cards.js
+++ b/blocks/v2-article-cards/v2-article-cards.js
@@ -30,7 +30,7 @@ const createCard = (article) => {
 
   const shortTitle = title.split('|')[0];
   const card = createElement('a', { classes: `${blockName}__article-card`, props: { href: url } });
-  const picture = createOptimizedPicture(image, shortTitle, false, [{ width: '380', height: '214' }]);
+  const picture = createOptimizedPicture(image, shortTitle, false);
   const pictureTag = picture.outerHTML;
   const formattedDate = getDateFromTimestamp(publishDate);
   const cardContent = document.createRange().createContextualFragment(`


### PR DESCRIPTION
## Note

The test URL uses the dev search URL. For some reason that makes that the cards are missing
like this:
<img width="1326" alt="Screenshot 2024-12-20 at 11 02 34" src="https://github.com/user-attachments/assets/02d59c08-ac3e-4aff-8a5d-aa1b19cbbb61" />

So, for test purposes, it's needed to use the devTools and mock the `isDevHost` value in the `search-api` as `true`

then it should look like this:
<img width="1281" alt="Screenshot 2024-12-20 at 11 03 36" src="https://github.com/user-attachments/assets/540b8c76-70e4-4de2-9abc-52bfea08816a" />


Fix #159

URL for testing:
- Before: https://main--volvotrucks-us--volvogroup.aem.page/news-and-stories/volvo-trucks-stories/
- After: https://159-blurry-images-overview-page--volvotrucks-us--volvogroup.aem.page/news-and-stories/volvo-trucks-stories/
