### PR TITLE
NFR: Update V2 Magazine template to gather the proper metadata #161

### DIFF
--- a/templates/v2-magazine/v2-magazine.js
+++ b/templates/v2-magazine/v2-magazine.js
@@ -86,8 +86,13 @@ const buildHeroMetadata = () => {
   return textContainer;
 };
 
+const splitTags = (tags) => tags.split(',').map((tag) => tag.trim());
+
 const buildHeroTags = () => {
-  const tags = getMetadata('article:tag').split(',');
+  const articleCategory = splitTags(getMetadata('article-category'));
+  const topic = splitTags(getMetadata('topic'));
+  const truck = splitTags(getMetadata('truck'));
+  const tags = [...articleCategory, ...topic, ...truck].filter((tag) => tag !== '').sort((a, b) => a.localeCompare(b));
   if (tags.length > 0 && tags[0] !== '') {
     const tagList = createElement('ul', { classes: `${articleHero}__tags` });
     tags.forEach((tag) => {


### PR DESCRIPTION
### Fix

The Hero added by the v2-magazine template got previously the tags from metadata `article:tag` metadata. Now it gets the values from the updated tags source: `article-category`, `topic` & `truck` instead of `article:tag`. Also, the tags are now sorted alphabetically.

#

Fix #161

URL for testing:
- Before: https://main--volvotrucks-us--volvogroup.aem.page/news-and-stories/volvo-trucks-stories/interior-amenities/
- After: https://161-magazine-template-metadata--volvotrucks-us--volvogroup.aem.page/news-and-stories/volvo-trucks-stories/interior-amenities/

