### PR TITLE
FR: Ensure video in modal is fully visible #255 #254 #257

### DIFF
--- a/common/modal/modal.css
+++ b/common/modal/modal.css
@@ -1,3 +1,8 @@
+/* stylelint-disable-next-line selector-class-pattern */
+body:has(.modal--reveal[aria-hidden="false"]) :where(._hj-widget-container, .ot-floating-button) {
+  display: none;
+}
+
 .modal-background {
   position: fixed;
   top: 0;
@@ -14,6 +19,7 @@
   --background-color: var(--c-white);
   --top-bar-height: 64px;
   --text-color: var(--c-black);
+  --modal-margin-top: 32px;
 }
 
 @supports (height: 1svh) {
@@ -66,6 +72,15 @@
 
 .modal-content:has(.modal-video) {
   text-align: center;
+}
+
+.modal-content:has(.modal-soundcloud) {
+  aspect-ratio: unset;
+}
+
+.modal--reveal .modal-content {
+  height: auto;
+  aspect-ratio: auto;
 }
 
 :root:not(.redesign-v2) .modal-content {
@@ -232,11 +247,6 @@
   gap: 2%;
 }
 
-/* stylelint-disable-next-line no-descending-specificity */
-.modal-content:has(.modal-soundcloud) {
-  aspect-ratio: unset;
-}
-
 .modal-content .modal-before-iframe:has(.modal-soundcloud) + iframe {
   height: 200px;
 }
@@ -255,9 +265,10 @@
 }
 
 .redesign-v2 .modal-content:has(.modal-video) {
-  margin-top: 32px;
+  margin-top: var(--modal-margin-top);
   padding: 0 16px;
   max-width: calc(var(--wrapper-width) + 32px);
+  max-height: calc(100% - var(--top-bar-height) - var(--modal-margin-top));
 }
 
 .redesign-v2 .modal-video {
@@ -268,13 +279,21 @@
 
 .redesign-v2 iframe.modal-video {
   aspect-ratio: 16/9;
+  max-height: 100%;
 }
 
 @media (min-width: 744px) {
+  .modal-background {
+    --modal-margin-top: 48px;
+  }
+
   .redesign-v2 .modal-content:has(.modal-video),
   .redesign-v2 .modal-content:has(.modal-cookie-message) {
-    margin-top: 48px;
     padding: 0 32px;
+  }
+
+  .redesign-v2 .modal-content:has(.modal-cookie-message) {
+    margin-top: var(--modal-margin-top);
   }
 
   .redesign-v2 .modal-video,
@@ -292,12 +311,6 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
-}
-
-/* stylelint-disable-next-line no-descending-specificity */
-.modal--reveal .modal-content {
-  height: auto;
-  aspect-ratio: auto;
 }
 
 .modal--reveal .section > div,
@@ -328,7 +341,7 @@
   .redesign-v2 .modal-cookie-message {
     width: 100%;
   }
-  
+
   .modal--reveal .section > div,
   .redesign-v2 .modal--video .section > div {
     padding-top: 48px;


### PR DESCRIPTION
### Update

Video modal iframe now its height is responsive too based on the screen size

### Other Updates

this also hides conditionally the _feedback_ and _cookie_ buttons

### Note

this is needed to go to PROD directly

#

Fix #255, #254 & #257

URL for testing:
- Before: https://main--volvotrucks-us--volvogroup.aem.page/
- After: https://255-video-modal-fully-visible--volvotrucks-us--volvogroup.aem.page/
