### PR TITLE
CR: V2 Key Facts Font Issue #256

### DIFF
--- a/blocks/v2-key-facts/v2-key-facts.css
+++ b/blocks/v2-key-facts/v2-key-facts.css
@@ -56,14 +56,14 @@
   line-height: calc(var(--title-scale-factor) * var(--f-heading-5-line-height));
 }
 
-.v2-key-facts .v2-key-facts__row--with-text .v2-key-facts__key-title-small {
-  --title-scale-factor: 0.7;
-}
-
 .v2-key-facts .v2-key-facts__row--with-text .v2-key-facts__key-subtitle {
   font-size: var(--f-subtitle-2-font-size);
   letter-spacing: var(--f-subtitle-2-letter-spacing);
   line-height: var(--f-subtitle-2-line-height);
+}
+
+.v2-key-facts__key-title-long {
+  display: none;
 }
 
 @media (min-width: 744px) {
@@ -115,11 +115,11 @@
   }
 
   .v2-key-facts .v2-key-facts__row--with-text .v2-key-facts__key-title {
-    font-size: var(--f-heading-2-font-size);
+    font-size: var(--f-heading-4-font-size);
     font-weight: 300;
   }
 
-  .v2-key-facts .v2-key-facts__row--with-text .v2-key-facts__key-title-small  {
-    font-size: var(--f-heading-4-font-size);
+  .v2-key-facts__key-title-long {
+    display: initial;
   }
 }

--- a/blocks/v2-key-facts/v2-key-facts.js
+++ b/blocks/v2-key-facts/v2-key-facts.js
@@ -1,7 +1,7 @@
+import { createElement } from '../../scripts/common.js';
 import { isVideoLink, createVideo } from '../../scripts/video-helper.js';
 
 const blockName = 'v2-key-facts';
-const MAX_WORD_LENGTH = 12;
 
 const CLASSES = {
   row: `${blockName}__row`,
@@ -11,7 +11,7 @@ const CLASSES = {
   image: `${blockName}__image`,
   key_item: `${blockName}__key-item`,
   item_title: `${blockName}__key-title`,
-  item_title_sm: `${blockName}__key-title-small`,
+  item_title_long: `${blockName}__key-title-long`,
   item_subtitle: `${blockName}__key-subtitle`,
 };
 
@@ -19,7 +19,13 @@ const buildTextsSection = (el) => {
   el.querySelectorAll('p').forEach((pEl, idx) => {
     if (idx === 0) {
       pEl.classList.add(CLASSES.item_title);
-      pEl.classList.toggle(CLASSES.item_title_sm, pEl.textContent.length >= MAX_WORD_LENGTH);
+      // If there is a <br> tag in the first paragraph, we need to wrap the text in a span to apply the styles
+      if (pEl.querySelector('br')) {
+        const span = createElement('span', { classes: CLASSES.item_title_long });
+        const childNodes = Array.from(pEl.childNodes).slice(1);
+        span.append(...childNodes);
+        pEl.append(span);
+      }
       return;
     }
     pEl.classList.add(CLASSES.item_subtitle);


### PR DESCRIPTION
# Fix

This update makes all v2-key-facts blue titles have the same size across viewports, like designs. 

## Also add

To avoid having a long title, if the title is too long with different rows (not used to be a subtitle) then it will be hidden in small viewports but visible in desktop viewport

## Note

The v1 version is not modified because the pages are using the `redesign-v2` style, so any page with a v1 needs to be updated in the content to a v2 version

# screenshot example

<img width="626" alt="Screenshot 2025-03-11 at 16 05 46" src="https://github.com/user-attachments/assets/d31915a2-cca9-46db-8254-ca6935c541a2" />

As can be seen in the example, the 4th title has linebreaks in its title and that becomes a `<br>` element. Any title with a linebreak will break into 2 pieces and be hidden if is too long

#
Fix #256

URL for testing:
- Before: https://main--volvotrucks-us--volvogroup.aem.page/trucks/vnl/#powertrain
- After: https://256-v2-key-facts-font-issue--volvotrucks-us--volvogroup.aem.page/trucks/vnl/#powertrain
