### PR TITLE
FR: Enable article filter to update magazine page #294 #295

### DIFF
--- a/blocks/v2-article-cards/v2-article-cards.css
+++ b/blocks/v2-article-cards/v2-article-cards.css
@@ -100,7 +100,6 @@
     --v2-article-cards-gutter: 20px;
 
     flex-flow: row wrap;
-    justify-content: space-between;
     max-width: var(--wrapper-width);
   }
 

--- a/blocks/v2-article-cards/v2-article-cards.js
+++ b/blocks/v2-article-cards/v2-article-cards.js
@@ -112,7 +112,36 @@ const filterDisplayedArticles = (articles) => {
 };
 
 export default async function decorate(block) {
-  const allArticles = await fetchMagazineArticles({ limit: 100 });
+  const currentURL = new URL(window.location);
+  const params = new URLSearchParams(currentURL.search);
+  const q = params.get('search');
+  const filters = ['truck', 'category', 'topic'];
+  const tags = {};
+  const options = { limit: 100 };
+  let hasFilters = false;
+
+  if (q) {
+    options.q = q;
+    hasFilters = true;
+  }
+
+  if (filters.some((filter) => params.get(filter))) {
+    filters.forEach((filter) => {
+      const filterParam = params.get(filter);
+      if (filterParam) {
+        tags[filter] = filterParam.split(',').map((item) => item.trim().replaceAll('-', ' '));
+      }
+    });
+
+    options.tags = tags;
+    hasFilters = true;
+  }
+
+  if (hasFilters) {
+    block.innerText = '';
+  }
+
+  const allArticles = await fetchMagazineArticles(options);
   const articles = removeArticlesWithNoImage(allArticles);
 
   if (!articles) {

--- a/blocks/v2-article-cards/v2-article-cards.js
+++ b/blocks/v2-article-cards/v2-article-cards.js
@@ -111,18 +111,16 @@ const filterDisplayedArticles = (articles) => {
   });
 };
 
-export default async function decorate(block) {
+const getFetchQueryOption = () => {
   const currentURL = new URL(window.location);
   const params = new URLSearchParams(currentURL.search);
-  const q = params.get('search');
+  const searchQuery = params.get('search');
   const filters = ['truck', 'category', 'topic'];
   const tags = {};
   const options = { limit: 100 };
-  let hasFilters = false;
 
-  if (q) {
-    options.q = q;
-    hasFilters = true;
+  if (searchQuery) {
+    options.q = searchQuery;
   }
 
   if (filters.some((filter) => params.get(filter))) {
@@ -134,8 +132,27 @@ export default async function decorate(block) {
     });
 
     options.tags = tags;
-    hasFilters = true;
   }
+
+  return options;
+};
+
+const queryHasFilters = () => {
+  const currentURL = new URL(window.location);
+  const params = new URLSearchParams(currentURL.search);
+  const searchQuery = params.get('search');
+  const filters = ['truck', 'category', 'topic'];
+
+  if (searchQuery || filters.some((filter) => params.get(filter))) {
+    return true;
+  }
+
+  return false;
+};
+
+export default async function decorate(block) {
+  const options = getFetchQueryOption();
+  const hasFilters = queryHasFilters();
 
   if (hasFilters) {
     block.innerText = '';

--- a/blocks/v2-article-cards/v2-article-cards.js
+++ b/blocks/v2-article-cards/v2-article-cards.js
@@ -142,12 +142,7 @@ const queryHasFilters = () => {
   const params = new URLSearchParams(currentURL.search);
   const searchQuery = params.get('search');
   const filters = ['truck', 'category', 'topic'];
-
-  if (searchQuery || filters.some((filter) => params.get(filter))) {
-    return true;
-  }
-
-  return false;
+  return Boolean(searchQuery || filters.some((filter) => params.get(filter)));
 };
 
 export default async function decorate(block) {

--- a/blocks/v2-article-cards/v2-article-cards.js
+++ b/blocks/v2-article-cards/v2-article-cards.js
@@ -111,7 +111,7 @@ const filterDisplayedArticles = (articles) => {
   });
 };
 
-const getFetchQueryOption = () => {
+const getQueryOptionsFromURL = () => {
   const currentURL = new URL(window.location);
   const params = new URLSearchParams(currentURL.search);
   const searchQuery = params.get('search');
@@ -137,7 +137,7 @@ const getFetchQueryOption = () => {
   return options;
 };
 
-const queryHasFilters = () => {
+const hasQueryFilters = () => {
   const currentURL = new URL(window.location);
   const params = new URLSearchParams(currentURL.search);
   const searchQuery = params.get('search');
@@ -146,8 +146,8 @@ const queryHasFilters = () => {
 };
 
 export default async function decorate(block) {
-  const options = getFetchQueryOption();
-  const hasFilters = queryHasFilters();
+  const options = getQueryOptionsFromURL();
+  const hasFilters = hasQueryFilters();
 
   if (hasFilters) {
     block.innerText = '';

--- a/blocks/v2-article-search/v2-article-search.js
+++ b/blocks/v2-article-search/v2-article-search.js
@@ -1,4 +1,12 @@
-import { decorateIcons, getPlaceholders, getTextLabel, getLocale, variantsClassesToBEM, getLanguagePath } from '../../scripts/common.js';
+import {
+  decorateIcons,
+  getPlaceholders,
+  getTextLabel,
+  getLocale,
+  variantsClassesToBEM,
+  getLanguagePath,
+  MAGAZINE_CONFIGS,
+} from '../../scripts/common.js';
 import { topicSearchQuery, fetchSearchData, TENANT } from '../../scripts/search-api.js';
 
 const blockName = 'v2-article-search';
@@ -16,22 +24,9 @@ const searchPlaceholder = getTextLabel('searchPlaceholder');
 const locale = getLocale();
 const language = locale.split('-')[0].toUpperCase();
 const languagePath = getLanguagePath();
-const hasLanguagePath = languagePath !== '/';
-
 const currentURL = new URL(window.location.href);
-// Previously:
-// const magazinePath = '/news-and-stories/volvo-trucks-stories/';
-// TODO: One day define the magazine full path in some config so we don't have this hardcoded logic
-// Now we are grabbing the first two parts of the path which will allow for translations if necessary
-// but this is still wrong since it has hardcoded paths, should be reviewed
-const { pathname } = currentURL;
-const currentPath = pathname.split('/').filter((segment) => segment !== '');
-if (hasLanguagePath) {
-  // If the language path exists, we need to remove it from the current path
-  currentPath.shift();
-}
-const [newsAndStories, mainStories] = currentPath;
-const magazinePath = `${languagePath}${newsAndStories}/${mainStories}/`;
+const { MAGAZINE_PATH } = MAGAZINE_CONFIGS;
+const magazinePath = `${languagePath}${MAGAZINE_PATH}`;
 const magazineParam = '?search=&category=&topic=&truck=';
 currentURL.pathname = magazinePath;
 currentURL.search = magazineParam;

--- a/blocks/v2-article-search/v2-article-search.js
+++ b/blocks/v2-article-search/v2-article-search.js
@@ -85,7 +85,7 @@ const buildFilterElement = () =>
     <div class="${blockName}__filter-list-wrapper"></div>
   </div>
 `);
-// no need to format the list items as they are already formatted in BE
+
 const buildBulletList = (allTopics) =>
   allTopics
     .map((item) => {

--- a/blocks/v2-article-search/v2-article-search.js
+++ b/blocks/v2-article-search/v2-article-search.js
@@ -17,7 +17,10 @@ const locale = getLocale();
 const language = locale.split('-')[0].toUpperCase();
 
 const currentURL = new URL(window.location.href);
-const magazinePath = '/news-and-stories/volvo-trucks-stories/';
+const { pathname } = currentURL;
+const currentPath = pathname.split('/').filter((segment) => segment !== '');
+const [newsAndStories, mainStories] = currentPath;
+const magazinePath = `/${newsAndStories}/${mainStories}/`;
 const magazineParam = '?search=&category=&topic=&truck=';
 currentURL.pathname = magazinePath;
 currentURL.search = magazineParam;

--- a/blocks/v2-article-search/v2-article-search.js
+++ b/blocks/v2-article-search/v2-article-search.js
@@ -6,7 +6,6 @@ const filterContainerClass = `${blockName}__filter-container`;
 const dropdownClass = `${blockName}__filter-dropdown`;
 const dropdownOpen = `${blockName}__filter-dropdown--open`;
 const filterListOpen = `${blockName}__filter-list-wrapper--open`;
-const filterActive = `${blockName}__filter-link--active`;
 const searchInputExpanded = `${blockName}__search-input--expanded`;
 const blockVariants = ['black', 'gray'];
 
@@ -18,7 +17,7 @@ const locale = getLocale();
 const language = locale.split('-')[0].toUpperCase();
 
 const currentURL = new URL(window.location.href);
-const magazinePath = '/news-and-stories/volvo-trucks-magazine/';
+const magazinePath = '/news-and-stories/volvo-trucks-stories/';
 const magazineParam = '?search=&category=&topic=&truck=';
 currentURL.pathname = magazinePath;
 currentURL.search = magazineParam;
@@ -86,22 +85,16 @@ const buildFilterElement = () =>
     <div class="${blockName}__filter-list-wrapper"></div>
   </div>
 `);
-
-// Capitalize the first letter of each word
-const formatValue = (item) => {
-  const { key, value } = item;
-  return key === 'truck' ? value.toUpperCase() : value.replace(/\b\w/g, (char) => char.toUpperCase());
-};
-
+// no need to format the list items as they are already formatted in BE
 const buildBulletList = (allTopics) =>
   allTopics
     .map((item) => {
-      const param = item.value.toLowerCase().replace(/\s/g, '-');
+      const param = item.value.replace(/\s/g, '-');
       currentURL.search = magazineParam;
       currentURL.searchParams.set(item.key, param);
       return `<li class="${blockName}__filter-item">
     <a href="${currentURL.href.replace('#', '')}"
-      class="${blockName}__filter-link">${formatValue(item)}</a>
+      class="${blockName}__filter-link">${item.value}</a>
   </li>`;
     })
     .join('');
@@ -122,30 +115,6 @@ const addDropdownHandler = (filter) => {
     const filterList = filterContainer.querySelector(`.${blockName}__filter-list-wrapper`);
     dropdown.classList.toggle(dropdownOpen);
     filterList.classList.toggle(filterListOpen);
-  });
-};
-
-const addFilterListHandler = (itemLink) => {
-  itemLink.addEventListener('click', (e) => {
-    if (e.target.tagName !== 'A') {
-      return;
-    }
-    const isActive = e.target.classList.contains(filterActive);
-    const filterList = e.target.closest(`.${blockName}__filter-list`);
-    const otherItems = [...filterList.querySelectorAll(`.${blockName}__filter-link`)].filter((item) => item !== e.target);
-    otherItems.forEach((item) => item.classList.remove(filterActive));
-    e.target.classList.toggle(filterActive);
-
-    // close the dropdown
-    if (isActive) {
-      e.preventDefault();
-      return;
-    }
-    const filterContainer = filterList.closest(`.${filterContainerClass}`);
-    const dropdown = filterContainer.querySelector(`.${dropdownClass}`);
-    const filterListWrapper = filterContainer.querySelector(`.${blockName}__filter-list-wrapper`);
-    dropdown.classList.remove(dropdownOpen);
-    filterListWrapper.classList.remove(filterListOpen);
   });
 };
 
@@ -224,7 +193,7 @@ const initializeSearchHandlers = (searchContainer) => {
     if (searchTerm) {
       currentURL.search = magazineParam;
       currentURL.searchParams.set('search', searchTerm);
-      window.open(currentURL.href, '_blank');
+      window.location.href = currentURL.href;
       collapseSearchContainer();
     }
   };
@@ -250,7 +219,6 @@ const decorateArticleSearch = async (block) => {
   filter.querySelector(`.${blockName}__filter-list-wrapper`).append(filterList);
   block.prepend(filter);
   addDropdownHandler(block.querySelector(`.${blockName}__filter-dropdown`));
-  addFilterListHandler(block.querySelector(`.${blockName}__filter-list`));
   addCloseHandler(block.querySelector('.icon-close'));
   const filterContainer = block.querySelector(`.${blockName}__filter-container`);
   if (filterContainer) {

--- a/blocks/v2-article-search/v2-article-search.js
+++ b/blocks/v2-article-search/v2-article-search.js
@@ -1,4 +1,4 @@
-import { decorateIcons, getPlaceholders, getTextLabel, getLocale, variantsClassesToBEM } from '../../scripts/common.js';
+import { decorateIcons, getPlaceholders, getTextLabel, getLocale, variantsClassesToBEM, getLanguagePath } from '../../scripts/common.js';
 import { topicSearchQuery, fetchSearchData, TENANT } from '../../scripts/search-api.js';
 
 const blockName = 'v2-article-search';
@@ -15,12 +15,23 @@ const searchPlaceholder = getTextLabel('searchPlaceholder');
 
 const locale = getLocale();
 const language = locale.split('-')[0].toUpperCase();
+const languagePath = getLanguagePath();
+const hasLanguagePath = languagePath !== '/';
 
 const currentURL = new URL(window.location.href);
+// Previously:
+// const magazinePath = '/news-and-stories/volvo-trucks-stories/';
+// TODO: One day define the magazine full path in some config so we don't have this hardcoded logic
+// Now we are grabing the first two parts of the path which will allow for translations if necessary
+// but this is still wrong since it has hardcoded paths, should be reviewed
 const { pathname } = currentURL;
 const currentPath = pathname.split('/').filter((segment) => segment !== '');
+if (hasLanguagePath) {
+  // If the language path exists, we need to remove it from the current path
+  currentPath.shift();
+}
 const [newsAndStories, mainStories] = currentPath;
-const magazinePath = `/${newsAndStories}/${mainStories}/`;
+const magazinePath = `${languagePath}${newsAndStories}/${mainStories}/`;
 const magazineParam = '?search=&category=&topic=&truck=';
 currentURL.pathname = magazinePath;
 currentURL.search = magazineParam;

--- a/blocks/v2-article-search/v2-article-search.js
+++ b/blocks/v2-article-search/v2-article-search.js
@@ -22,7 +22,7 @@ const currentURL = new URL(window.location.href);
 // Previously:
 // const magazinePath = '/news-and-stories/volvo-trucks-stories/';
 // TODO: One day define the magazine full path in some config so we don't have this hardcoded logic
-// Now we are grabing the first two parts of the path which will allow for translations if necessary
+// Now we are grabbing the first two parts of the path which will allow for translations if necessary
 // but this is still wrong since it has hardcoded paths, should be reviewed
 const { pathname } = currentURL;
 const currentPath = pathname.split('/').filter((segment) => segment !== '');

--- a/constants.json
+++ b/constants.json
@@ -158,6 +158,10 @@
       {
         "name": "DATE_OPTIONS_MOBILE",
         "value": "[\"month: 2-digit\",\"day: 2-digit\",\"year: numeric\"]"
+      },
+      {
+        "name": "MAGAZINE_PATH",
+        "value": "news-and-stories/volvo-trucks-stories/"
       }
     ]
   },

--- a/scripts/search-api.js
+++ b/scripts/search-api.js
@@ -1,15 +1,14 @@
-import { isDevHost, SEARCH_CONFIGS } from './common.js';
+import { SEARCH_CONFIGS } from './common.js';
 
-export const { TENANT = false, SEARCH_URL_DEV = false, SEARCH_URL_PROD = false } = SEARCH_CONFIGS;
-const isProd = !isDevHost();
-const SEARCH_LINK = !isProd ? SEARCH_URL_DEV : SEARCH_URL_PROD;
+export const { TENANT = false, SEARCH_URL_PROD = false } = SEARCH_CONFIGS;
 
+// because the dev url has different items is better to use the prod one also in dev
 export async function fetchSearchData(queryObj) {
   try {
-    if (!SEARCH_LINK) {
+    if (!SEARCH_URL_PROD) {
       throw new Error('Search link not found');
     }
-    const response = await fetch(SEARCH_LINK, {
+    const response = await fetch(SEARCH_URL_PROD, {
       method: 'POST',
       headers: {
         Accept: 'application/json',

--- a/scripts/services/magazine.service.js
+++ b/scripts/services/magazine.service.js
@@ -2,9 +2,9 @@ import { getLocale } from '../common.js';
 import { fetchSearchData, magazineSearchQuery, TENANT } from '../search-api.js';
 
 /**
- * Extracts the articles that dont have an image field
+ * Extracts the articles that don't have an image field
  * @param {Array} articles - An array of articles
- * @returns {Array} - The same array of articles but without those that dont have an image field
+ * @returns {Array} - The same array of articles but without those that don't have an image field
  */
 export const removeArticlesWithNoImage = (articles) => {
   const filteredArray = [...articles.items];
@@ -99,7 +99,7 @@ export const sortArticlesByDateField = (articles, dateField) => {
  * @param {Object} options - Options for fetching magazine articles.
  * @param {number} options.limit - The maximum number of articles to fetch.
  * @param {number} [options.offset=0] - The starting point for fetching articles (pagination).
- * @param {Array<string>|null} [options.tags=null] - Tags to filter articles.
+ * @param {Object|null} [options.tags=null] - An object with keys "truck", "topic" and/or "category" to filter articles, or null.
  * @param {string} [options.q='truck'] - The query term to search for articles.
  * @param {string} [options.sort] - The sorting criteria for articles.
  * @param {string} [options.tenant=TENANT] - The tenant identifier.


### PR DESCRIPTION
# Fix

In this fix the magazine filter updates the URL and the `v2-article-cards block` content to reflect the filtering. The search result also is shown on the page without the need to open a new tab. In an article page, the filtering goes to the main Magazine page to show the results.

## Also fix

A time ago, the data grabbed from the metadata and stored in the search engine was transformed in lowercase, so in FE was needed to be retransform again. Now BE no longer does that so is not needed to retransform in FE again. That fixes issue #295

### Update

Added a languagePath checker to apply also the fix for the Canada site

#
Fix #294, #295

URL for testing:
- Before: https://main--volvotrucks-us--volvogroup.aem.page/news-and-stories/volvo-trucks-stories/
- After: https://294-enable-article-filter--volvotrucks-us--volvogroup.aem.page/news-and-stories/volvo-trucks-stories/

URL with search:
- Before: https://main--volvotrucks-us--volvogroup.aem.page/news-and-stories/volvo-trucks-stories/?search=&category=&topic=&truck=All-Truck-Series
- After: https://294-enable-article-filter--volvotrucks-us--volvogroup.aem.page/news-and-stories/volvo-trucks-stories/?search=&category=&topic=&truck=All-Truck-Series

Magazine URL:
- Before: https://main--volvotrucks-us--volvogroup.aem.page/news-and-stories/volvo-trucks-stories/introducing-volvo-connect/
- After: https://294-enable-article-filter--volvotrucks-us--volvogroup.aem.page/news-and-stories/volvo-trucks-stories/introducing-volvo-connect/

CA site:
- After: https://294-enable-article-filter--volvotrucks-ca--volvogroup.aem.page/en-ca/news-and-stories/volvo-trucks-stories/introducing-volvo-connect/


