### PR TITLE
FR: Double Column Variant Form for the MCAE - VT #283

### DIFF
--- a/blocks/v2-custom-form/v2-custom-form.css
+++ b/blocks/v2-custom-form/v2-custom-form.css
@@ -129,3 +129,18 @@
     width: 100%;
   }
 }
+
+@media (min-width: 1200px) {
+  .v2-custom-form--double-column form {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 16px 32px;
+    max-width: 980px;
+    width: 100%;
+    margin: 0 auto;
+  }
+
+  .v2-custom-form-container :is(.form-textarea-wrapper, .form-submit-wrapper) {
+    grid-column: 1 / -1;
+  }
+}

--- a/blocks/v2-custom-form/v2-custom-form.js
+++ b/blocks/v2-custom-form/v2-custom-form.js
@@ -1,8 +1,9 @@
 import { loadScript, sampleRUM } from '../../scripts/aem.js';
-import { getTextLabel, createElement } from '../../scripts/common.js';
+import { getTextLabel, createElement, variantsClassesToBEM } from '../../scripts/common.js';
 import { getCustomDropdown } from '../../../common/custom-dropdown/custom-dropdown.js';
 
 const blockName = 'v2-custom-form';
+const variantClasses = ['double-column'];
 
 const successMessage = (successTitle, successText) => `<h3 class='${blockName}__title ${blockName}__title--success'>${successTitle}</h3>
 <p class='${blockName}__text ${blockName}__text--success'>${successText}</p>
@@ -557,6 +558,7 @@ function decorateTitles(block) {
 }
 
 export default async function decorate(block) {
+  variantsClassesToBEM(block.classList, variantClasses, blockName);
   const formLink = block.querySelector('a[href$=".json"]');
   const thankYouPage = [...block.querySelectorAll('a')].filter((a) => a.href.includes('thank-you'));
 


### PR DESCRIPTION
# Update

This Update adds a `Double Column` variant to _v2-Custom-Form_ Block. It's already added to the library as the list's last item variant

Fix #283

URL for testing:
- Before: https://main--volvotrucks-us--volvogroup.aem.page/drafts/jlledo/v2-2-columns-form-demo
- After: https://283-double-column-form--volvotrucks-us--volvogroup.aem.page/drafts/jlledo/v2-2-columns-form-demo

Library link page (last form):

- Before: https://main--volvotrucks-ca--volvogroup.aem.page/block-library/blocks/v2-custom-form
- After: https://283-double-column-form--volvotrucks-ca--volvogroup.aem.page/block-library/blocks/v2-custom-form

Library item

- Before: https://main--volvotrucks-us--volvogroup.aem.page/tools/sidekick/library.html?plugin=blocks&path=/block-library/blocks/v2-custom-form&index=4

- After: https://283-double-column-form--volvotrucks-us--volvogroup.aem.page/tools/sidekick/library.html?plugin=blocks&path=/block-library/blocks/v2-custom-form&index=4
