### PR TITLE
NFR: Language setting needs to be applied to all website - VT #169

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -801,8 +801,9 @@ async function loadEager(doc) {
   if (main) {
     decorateMain(main, head);
     document.body.classList.add('appear');
-    const language = getLocale();
-    document.documentElement.lang = language;
+    const meta_i18n = doc.querySelector('meta[name="i18n"]');
+    const meta_locale = doc.querySelector('meta[name="locale"]');
+    document.documentElement.lang = (meta_i18n && meta_i18n.content) || (meta_locale && meta_locale.content.toLowerCase()) || 'en';
     const templateName = getMetadata('template');
     if (templateName) {
       await loadTemplate(doc, templateName);


### PR DESCRIPTION
Fix #169

URL for testing:
- Before: https://main--volvotrucks-us--volvogroup.aem.page/
- After: https://169-html-lang-settings--volvotrucks-us--volvogroup.aem.page/

Other markets:

Canada:
- Before: https://main--volvotrucks-ca--volvogroup.aem.page/
- After: https://169-html-lang-settings--volvotrucks-ca--volvogroup.aem.page/

Mexico:
- Before: https://main--volvotrucks-mx--volvogroup.aem.page/
- After: https://169-html-lang-settings--volvotrucks-mx--volvogroup.aem.page/
