### PR TITLE
NFR: FE language query standarization #149

### DIFF
--- a/blocks/search/autosuggest.js
+++ b/blocks/search/autosuggest.js
@@ -5,8 +5,8 @@ const autoSuggestClass = 'autosuggest-results-item-highlighted';
 
 export function fetchAutosuggest(term, autosuggestEle, rowEle, func) {
   const fragmentRange = document.createRange();
-  const language = getLocale();
-  const locale = language.split('-')[0].toUpperCase();
+  const locale = getLocale();
+  const language = locale.split('-')[0].toUpperCase();
 
   if (!TENANT) {
     console.error('%cTenant %cis not defined', 'color: red', 'color: default');
@@ -18,7 +18,7 @@ export function fetchAutosuggest(term, autosuggestEle, rowEle, func) {
     variables: {
       tenant: TENANT,
       term,
-      locale,
+      language,
       sizeSuggestions: 5,
     },
   }).then(({ errors, data }) => {

--- a/scripts/search-api.js
+++ b/scripts/search-api.js
@@ -70,8 +70,8 @@ $facets: [EdsFieldEnum], $sort: EdsSortOptionsEnum, $article: ArticleFilter, $ca
 `;
 
 export const autosuggestQuery = () => `
-query Edssuggest($term: String!, $tenant: String!, $locale: EdsLocaleEnum!, $sizeSuggestions: Int) {
-  edssuggest(term: $term, tenant: $tenant, locale: $locale, sizeSuggestions: $sizeSuggestions) {
+query edssuggest($term: String!, $tenant: String!, $language: EdsLocaleEnum!, $sizeSuggestions: Int = 8) {
+  edssuggest(term: $term, tenant: $tenant, language: $language, sizeSuggestions: $sizeSuggestions) {
     terms
   }
 }


### PR DESCRIPTION
Fix #149

URL for testing:
- Before: https://main--volvotrucks-us--volvogroup.aem.page/
- After: https://149-autosuggest-lang--volvotrucks-us--volvogroup.aem.page/

Other markets:

Canada:
- Before: https://main--volvotrucks-ca--volvogroup.aem.page/
- After: https://149-autosuggest-lang--volvotrucks-ca--volvogroup.aem.page/

Mexico:
- Before: https://main--volvotrucks-mx--volvogroup.aem.page/
- After: https://149-autosuggest-lang--volvotrucks-mx--volvogroup.aem.page/
