### PR TITLE
CR: Update V2 Stories Carousel block filtering logic #330

### DIFF
--- a/blocks/v2-stories-carousel/v2-stories-carousel.js
+++ b/blocks/v2-stories-carousel/v2-stories-carousel.js
@@ -1,4 +1,4 @@
-import { createOptimizedPicture, getMetadata, decorateIcons, toClassName } from '../../scripts/aem.js';
+import { createOptimizedPicture, getMetadata, decorateIcons } from '../../scripts/aem.js';
 import { createElement, getDateFromTimestamp, MAGAZINE_CONFIGS, extractObjectFromArray, getTextLabel } from '../../scripts/common.js';
 import {
   clearCurrentArticle,
@@ -15,11 +15,7 @@ const highLimit = 7;
 
 const updateActiveClass = (elements, targetElement) => {
   elements.forEach((el) => {
-    if (el === targetElement) {
-      el.classList.add('active');
-    } else {
-      el.classList.remove('active');
-    }
+    el.classList.toggle('active', el === targetElement);
   });
 };
 
@@ -127,7 +123,7 @@ const getArticleTags = (metadata) => [
 ];
 
 const getMagazineArticles = async (limit = 5, tags = []) => {
-  const allArticles = await fetchMagazineArticles({ limit: 100 });
+  const allArticles = await fetchMagazineArticles({ sort: 'PUBLISH_DATE_DESC' });
   const artsWithImage = removeArticlesWithNoImage(allArticles);
   let articles = clearCurrentArticle(artsWithImage);
 
@@ -138,7 +134,7 @@ const getMagazineArticles = async (limit = 5, tags = []) => {
   // If tags are present, filter the article list using the specified tags.
   if (tags.length > 0) {
     articles = articles.filter((article) => {
-      const articleTags = getArticleTags(article.metadata).map((tag) => toClassName(tag.trim()));
+      const articleTags = getArticleTags(article.metadata).map((tag) => tag.trim());
       return articleTags.some((articleTag) => tags.includes(articleTag));
     });
   }
@@ -146,7 +142,7 @@ const getMagazineArticles = async (limit = 5, tags = []) => {
   // If the number of articles is less than the limit, complete the list with additional articles.
   if (articles.length < limit) {
     const missingArticles = artsWithImage.filter((art) => {
-      const articleTags = getArticleTags(art.metadata).map((tag) => toClassName(tag.trim()));
+      const articleTags = getArticleTags(art.metadata).map((tag) => tag.trim());
       return !tags.some((tag) => articleTags.includes(tag));
     });
     const sortedArticles = sortArticlesByDateField(missingArticles, 'publishDate');
@@ -232,7 +228,7 @@ export default async function decorate(block) {
     const tags = metadataTags.reduce((acc, metaTag) => {
       const metaContent = getMetadata(metaTag);
       if (metaContent) {
-        acc.push(...metaContent.split(',').map((tag) => toClassName(tag.trim())));
+        acc.push(...metaContent.split(',').map((tag) => tag.trim()));
       }
       return acc;
     }, []);

--- a/scripts/services/magazine.service.js
+++ b/scripts/services/magazine.service.js
@@ -41,22 +41,55 @@ export const extractLimitFromBlock = (block) => {
 };
 
 /**
+ * Extracts the last folder from a URL.
+ *
+ * @param {string} url - The URL from which to extract the last folder.
+ * @returns {string} The last folder in the URL.
+ *
+ * @example
+ * // Example usage:
+ * const url = 'https://example.com/folder1/folder2';
+ * const lastFolder = getLastURLFolder(url);
+ * console.log(lastFolder); // Output: 'folder2'
+ *
+ * @description
+ * This function splits the URL by '/' and filters out any empty segments.
+ * It then returns the last non-empty segment, which represents the last folder in the URL.
+ * */
+const getLastURLFolder = (url) =>
+  url
+    .split('/')
+    .filter((item) => item.trim() !== '')
+    .pop();
+
+/**
  * Filters out the current article from the list of articles.
  *
  * @param {Array<Object>} articles - The list of articles to filter.
  * @returns {Array<Object>} - The filtered list of articles excluding the current article.
+ *
+ * @example
+ * // Example usage:
+ * const articles = [
+ *  { metadata: { url: 'https://example.com/article1' } },
+ *  { metadata: { url: 'https://example.com/article2' } },
+ *  { metadata: { url: 'https://example.com/article3' } },
+ * ];
+ * const filteredArticles = clearCurrentArticle(articles);
+ * console.log(filteredArticles);
+ * // Output: [{ metadata: { url: 'https://example.com/article1' } }, { metadata: { url: 'https://example.com/article2' } }]
+ *
+ * @description
+ * This function filters out the current article from the list of articles based on the URL.
+ * It compares the last folder of the current URL with the last folder of each article's URL.
+ * If they match, the article is excluded from the filtered list.
+ * The function returns a new array containing only the articles that do not match the current article's URL.
  */
 export const clearCurrentArticle = (articles) =>
   articles.filter((article) => {
-    const currentArticlePath = window.location.href.split('/').pop();
-    const lastElementInUrl = article.metadata.url
-      .split('/')
-      .filter((item) => item.trim() !== '')
-      .pop();
-    if (lastElementInUrl !== currentArticlePath) {
-      return article;
-    }
-    return null;
+    const currentArticlePath = getLastURLFolder(window.location.href);
+    const lastElementInUrl = getLastURLFolder(article.metadata.url);
+    return lastElementInUrl !== currentArticlePath ? article : null;
   });
 
 /**
@@ -114,9 +147,9 @@ export const sortArticlesByDateField = (articles, dateField) => {
  * @throws {Error} Logs errors to the console and returns null if the fetch fails.
  */
 export const fetchMagazineArticles = async ({
-  limit,
+  limit = 100,
   offset = 0,
-  tags = null,
+  tags = {},
   q = 'truck',
   sort,
   tenant = TENANT,
@@ -129,11 +162,11 @@ export const fetchMagazineArticles = async ({
     language,
     q,
     category,
-    limit: limit ?? null,
+    limit,
     offset,
     facets,
     sort,
-    article: tags || {},
+    article: tags,
   };
 
   try {


### PR DESCRIPTION
# Update

Tags metadata is no longer taken into account, and it grabs the tags from the 3 other tag types, such as article-category, topic and truck. In the future, as soon as the a-category is moved to the topic row, then no more development will be needed because that value will be empty.

Added also a little bug that didn't remove the current article

#

#Fix #330

URL for testing:
- Before: https://main--volvotrucks-us--volvogroup.aem.page/news-and-stories/volvo-trucks-stories/cover-story-designed-to-change-everything/
- After: https://330-new-filter-logic--volvotrucks-us--volvogroup.aem.page/news-and-stories/volvo-trucks-stories/cover-story-designed-to-change-everything/

Other markets:

Canada:
- Before: https://main--volvotrucks-ca--volvogroup.aem.page/en-ca/news-and-stories/volvo-trucks-stories/cover-story-designed-to-change-everything/
- After: https://330-new-filter-logic--volvotrucks-ca--volvogroup.aem.page/en-ca/news-and-stories/volvo-trucks-stories/cover-story-designed-to-change-everything/
