### PR TITLE
Bug: Press Releases Not Sorting Correctly on FR-CA Press Releases Page #362

### DIFF
--- a/.github/ci/generate-news-feed-config.js
+++ b/.github/ci/generate-news-feed-config.js
@@ -1,5 +1,15 @@
+function getOrigin() {
+  return window.location.href === 'about:srcdoc' ? window.parent.location.origin : window.location.origin;
+}
+
+function getLanguagePath() {
+  const { pathname } = new URL(window.location.href);
+  const langCodeMatch = pathname.match('^(/[a-z]{2}(-[a-z]{2})?/).*');
+  return langCodeMatch ? langCodeMatch[1] : '/';
+}
+
 async function getConstantValues() {
-  const url = '/constants.json';
+  const url = new URL(`${getLanguagePath()}constants.json`, getOrigin());
   let constants;
   try {
     const response = await fetch(url).then((resp) => resp.json());


### PR DESCRIPTION
Fix #362 

URL for testing:
- Before: https://main--volvotrucks-us--volvogroup.aem.page/fr-ca/news-and-stories/press-releases/
- After: https://362-bug-press-rel--volvotrucks-us--volvogroup.aem.page/fr-ca/news-and-stories/press-releases/

Other markets:

Canada:
- Before: https://main--volvotrucks-ca--volvogroup.aem.page/
- After: https://<branch>--volvotrucks-ca--volvogroup.aem.page/

Mexico:
- Before: https://main--volvotrucks-mx--volvogroup.aem.page/
- After: https://<branch>--volvotrucks-mx--volvogroup.aem.page/
