### PR TITLE
Spike: Update GitHub Actions - Notifications (2 of 4) #89

### DIFF
--- a/.github/workflows/publish-notifier.yaml
+++ b/.github/workflows/publish-notifier.yaml
@@ -1,6 +1,6 @@
 name: Search Connector - Upsert
 
-on: 
+on:
   repository_dispatch:
     types:
       - resource-published
@@ -26,5 +26,12 @@ jobs:
         BODY='{ "paths": [ "'$PAGE_PATH'" ] }'
         BODY="$(echo "$BODY" | jq -c)"
         response=$(curl -s -H "x-api-key: ${{ secrets.API_KEY }}" -X POST "$URI" -d "$BODY")
+
+        # Send email notification if enabled
+        if [ "${{ vars.SEND_EMAIL_NOTIFICATION }}" = "true" ]; then
+          echo "Sending email notification..."
+          echo -e "Subject: Search Connector Update\nTo: ${{ vars.EMAIL_RECIPIENT }}\n\nPage updated: $PAGE_PATH\nWebsite: $WEBSITE_NAME\nResponse: $response" | sendmail "${{ vars.EMAIL_RECIPIENT }}"
+        fi
+
         echo "response: $response"
       shell: bash


### PR DESCRIPTION
# Note

For the purpose of this ticket, the only way to test this is in Production, so it needs to go directly to `main`, then check if this change works in the action that is the focus of the test (publish action by now) and then validate it directly in production. If the publish action triggers successfully, then the remaining action will need to be updated too (the unpublish one, with the same approach).

#
Fix #89

No test links needed, just check if the publish GitHub action triggers correctly.
