### PR TITLE
Spike: Update GitHub Actions - Notifications (2 of 4) #89 

### DIFF
--- a/.github/workflows/publish-notifier.yaml
+++ b/.github/workflows/publish-notifier.yaml
@@ -7,19 +7,14 @@ on:
 jobs:
   check-event-status:
     runs-on: ubuntu-latest
-    env:
-      STATUS: ${{ github.event.client_payload.status }}
-      SITE: ${{ github.event.client_payload.site }}
-      ORG: ${{ github.event.client_payload.org }}
-      PATH: ${{ github.event.client_payload.path }}
     steps:
     - run: |
-        echo "Status: $STATUS"
-        echo "Site: $SITE"
-        echo "Org: $ORG"
-        echo "Path: $PATH"
+        echo "Status: ${{ github.event.client_payload.status }}"
+        echo "Site: ${{ github.event.client_payload.site }}"
+        echo "Org: ${{ github.event.client_payload.org }}"
+        echo "Path: ${{ github.event.client_payload.path }}"
   notify-connector:
-    if: ($STATUS == 200 || $STATUS == 204) && endsWith($PATH, '.md')
+    if: (github.event.client_payload.status == 200 || github.event.client_payload.status == 204) && endsWith(github.event.client_payload.path, '.md')
     runs-on: ubuntu-latest
     steps:
     - name: Notify upsert endpoint
@@ -60,7 +55,7 @@ jobs:
             # Send email notification via Brevo (Sendinblue) if enabled
             if [[ "$SEND_EMAIL_NOTIFICATION" == "true" ]]; then
               response=$(curl -s -X POST \
-                '$EMAIL_HANDLER' \
+                "$EMAIL_HANDLER" \
                 -H "accept: application/json" \
                 -H "api-key: $BREVO_API_KEY" \
                 -H "content-type: application/json" \

--- a/.github/workflows/publish-notifier.yaml
+++ b/.github/workflows/publish-notifier.yaml
@@ -1,6 +1,6 @@
 name: Search Connector - Upsert
 
-on: 
+on:
   repository_dispatch:
     types:
       - resource-published
@@ -26,5 +26,12 @@ jobs:
         BODY='{ "paths": [ "'$PAGE_PATH'" ] }'
         BODY="$(echo "$BODY" | jq -c)"
         response=$(curl -s -H "x-api-key: ${{ secrets.API_KEY }}" -X POST "$URI" -d "$BODY")
+
+        # Send email notification if enabled
+        if [ "${{ vars.SEND_EMAIL_NOTIFICATION }}" = "true" ]; then
+          echo "Sending email notification..."
+          echo -e "Subject: Search Connector Update\nTo: ${{ vars.EMAIL_RECIPIENT }}\n\nPage updated: $PAGE_PATH\nWebsite: $WEBSITE_NAME\nResponse: $response" | sendmail "${{ vars.EMAIL_RECIPIENT }}"
+        fi
+
         echo "response: $response"
       shell: bash

--- a/.github/workflows/publish-notifier.yaml
+++ b/.github/workflows/publish-notifier.yaml
@@ -26,12 +26,33 @@ jobs:
         BODY='{ "paths": [ "'$PAGE_PATH'" ] }'
         BODY="$(echo "$BODY" | jq -c)"
         response=$(curl -s -H "x-api-key: ${{ secrets.API_KEY }}" -X POST "$URI" -d "$BODY")
-
-        # Send email notification if enabled
-        if [ "${{ vars.SEND_EMAIL_NOTIFICATION }}" = "true" ]; then
-          echo "Sending email notification..."
-          echo -e "Subject: Search Connector Update\nTo: ${{ vars.EMAIL_RECIPIENT }}\n\nPage updated: $PAGE_PATH\nWebsite: $WEBSITE_NAME\nResponse: $response" | sendmail "${{ vars.EMAIL_RECIPIENT }}"
-        fi
-
         echo "response: $response"
       shell: bash
+  check-status:
+    needs: notify-connector
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Check notify-connector status
+        run: |
+          if [[ "${{ needs.notify-connector.result }}" == "failure" ]]; then
+            echo "notify-connector job failed."
+            # Send email notification via Brevo (Sendinblue) if enabled
+            if [[ "${{ vars.SEND_EMAIL_NOTIFICATION }}" == "true" ]]; then
+              response=$(curl -s -X POST \
+                'https://api.brevo.com/v3/smtp/email' \
+                -H "accept: application/json" \
+                -H "api-key: ${{ secrets.BREVO_API_KEY }}" \
+                -H "content-type: application/json" \
+                -d '{
+                  "sender": { "email": "'"${{ vars.EMAIL_SENDER }}"'" },
+                  "to": [ { "email": "'"${{ vars.EMAIL_RECIPIENT }}"'" } ],
+                  "subject": "notify-connector job FAILED",
+                  "textContent": "The notify-connector job has FAILED.\nRepository: ${{ github.repository }}\nPath: ${{ github.event.client_payload.path }}\nSite: ${{ github.event.client_payload.site }}"
+                }')
+              echo "Brevo email sent. Response: $response"
+            fi
+            exit 1
+          else
+            echo "notify-connector job succeeded."
+          fi

--- a/.github/workflows/publish-notifier.yaml
+++ b/.github/workflows/publish-notifier.yaml
@@ -18,14 +18,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Notify upsert endpoint
+      env:
+        CONNECTOR_DOMAIN: ${{ vars.CONNECTOR_DOMAIN }}
+        API_KEY: ${{ secrets.API_KEY }}
       run: |
         sleep 45s
         PAGE_PATH=$(echo "${{ github.event.client_payload.path }}" | awk '{sub("index.md$", ""); sub(".md$", ""); print}')
         WEBSITE_NAME="${{ github.event.client_payload.site }}"
-        URI=$(echo "${{ vars.CONNECTOR_DOMAIN }}/$WEBSITE_NAME")
+        URI=$(echo "$CONNECTOR_DOMAIN/$WEBSITE_NAME")
         BODY='{ "paths": [ "'$PAGE_PATH'" ] }'
         BODY="$(echo "$BODY" | jq -c)"
-        response=$(curl -s -H "x-api-key: ${{ secrets.API_KEY }}" -X POST "$URI" -d "$BODY")
+        response=$(curl -s -H "x-api-key: $API_KEY" -X POST "$URI" -d "$BODY")
         echo "response: $response"
       shell: bash
   check-status:
@@ -34,19 +37,24 @@ jobs:
     if: always()
     steps:
       - name: Check notify-connector status
+        env:
+          SEND_EMAIL_NOTIFICATION: ${{ vars.SEND_EMAIL_NOTIFICATION }}
+          EMAIL_SENDER: ${{ secrets.EMAIL_SENDER }}
+          EMAIL_RECIPIENT: ${{ secrets.EMAIL_RECIPIENT }}
+          BREVO_API_KEY: ${{ secrets.BREVO_API_KEY }}
         run: |
           if [[ "${{ needs.notify-connector.result }}" == "failure" ]]; then
             echo "notify-connector job failed."
             # Send email notification via Brevo (Sendinblue) if enabled
-            if [[ "${{ vars.SEND_EMAIL_NOTIFICATION }}" == "true" ]]; then
+            if [[ "$SEND_EMAIL_NOTIFICATION" == "true" ]]; then
               response=$(curl -s -X POST \
                 'https://api.brevo.com/v3/smtp/email' \
                 -H "accept: application/json" \
-                -H "api-key: ${{ secrets.BREVO_API_KEY }}" \
+                -H "api-key: $BREVO_API_KEY" \
                 -H "content-type: application/json" \
                 -d '{
-                  "sender": { "email": "'"${{ vars.EMAIL_SENDER }}"'" },
-                  "to": [ { "email": "'"${{ vars.EMAIL_RECIPIENT }}"'" } ],
+                  "sender": { "email": "'"$EMAIL_SENDER"'" },
+                  "to": [ { "email": "'"$EMAIL_RECIPIENT"'" } ],
                   "subject": "notify-connector job FAILED",
                   "textContent": "The notify-connector job has FAILED.\nRepository: ${{ github.repository }}\nPath: ${{ github.event.client_payload.path }}\nSite: ${{ github.event.client_payload.site }}"
                 }')
@@ -56,3 +64,4 @@ jobs:
           else
             echo "notify-connector job succeeded."
           fi
+

--- a/.github/workflows/publish-notifier.yaml
+++ b/.github/workflows/publish-notifier.yaml
@@ -7,24 +7,31 @@ on:
 jobs:
   check-event-status:
     runs-on: ubuntu-latest
+    env:
+      STATUS: ${{ github.event.client_payload.status }}
+      SITE: ${{ github.event.client_payload.site }}
+      ORG: ${{ github.event.client_payload.org }}
+      PATH: ${{ github.event.client_payload.path }}
     steps:
     - run: |
-        echo "Status: ${{ github.event.client_payload.status }}"
-        echo "Site: ${{ github.event.client_payload.site }}"
-        echo "Org: ${{ github.event.client_payload.org }}"
-        echo "Path: ${{ github.event.client_payload.path }}"
+        echo "Status: $STATUS"
+        echo "Site: $SITE"
+        echo "Org: $ORG"
+        echo "Path: $PATH"
   notify-connector:
-    if: (github.event.client_payload.status == 200 || github.event.client_payload.status == 204) && endsWith(github.event.client_payload.path, '.md')
+    if: ($STATUS == 200 || $STATUS == 204) && endsWith($PATH, '.md')
     runs-on: ubuntu-latest
     steps:
     - name: Notify upsert endpoint
       env:
         CONNECTOR_DOMAIN: ${{ vars.CONNECTOR_DOMAIN }}
         API_KEY: ${{ secrets.API_KEY }}
+        PATH: ${{ github.event.client_payload.path }}
+        SITE: ${{ github.event.client_payload.site }}
       run: |
         sleep 45s
-        PAGE_PATH=$(echo "${{ github.event.client_payload.path }}" | awk '{sub("index.md$", ""); sub(".md$", ""); print}')
-        WEBSITE_NAME="${{ github.event.client_payload.site }}"
+        PAGE_PATH=$(echo "$PATH" | awk '{sub("index.md$", ""); sub(".md$", ""); print}')
+        WEBSITE_NAME="$SITE"
         URI=$(echo "$CONNECTOR_DOMAIN/$WEBSITE_NAME")
         BODY='{ "paths": [ "'$PAGE_PATH'" ] }'
         BODY="$(echo "$BODY" | jq -c)"
@@ -42,13 +49,18 @@ jobs:
           EMAIL_SENDER: ${{ secrets.EMAIL_SENDER }}
           EMAIL_RECIPIENT: ${{ secrets.EMAIL_RECIPIENT }}
           BREVO_API_KEY: ${{ secrets.BREVO_API_KEY }}
+          JOB_RESULT: ${{ needs.notify-connector.result }}
+          REPO: ${{ github.repository }}
+          PATH: ${{ github.event.client_payload.path }}
+          SITE: ${{ github.event.client_payload.site }}
+          EMAIL_HANDLER: ${{ secrets.EMAIL_HANDLER }}
         run: |
-          if [[ "${{ needs.notify-connector.result }}" == "failure" ]]; then
+          if [[ "$JOB_RESULT" == "failure" ]]; then
             echo "notify-connector job failed."
             # Send email notification via Brevo (Sendinblue) if enabled
             if [[ "$SEND_EMAIL_NOTIFICATION" == "true" ]]; then
               response=$(curl -s -X POST \
-                'https://api.brevo.com/v3/smtp/email' \
+                '$EMAIL_HANDLER' \
                 -H "accept: application/json" \
                 -H "api-key: $BREVO_API_KEY" \
                 -H "content-type: application/json" \
@@ -56,7 +68,7 @@ jobs:
                   "sender": { "email": "'"$EMAIL_SENDER"'" },
                   "to": [ { "email": "'"$EMAIL_RECIPIENT"'" } ],
                   "subject": "notify-connector job FAILED",
-                  "textContent": "The notify-connector job has FAILED.\nRepository: ${{ github.repository }}\nPath: ${{ github.event.client_payload.path }}\nSite: ${{ github.event.client_payload.site }}"
+                  "textContent": "The notify-connector job has FAILED.\nRepository: $REPO\nPath: $PATH\nSite: $SITE\n\nPlease check the job logs for more details."
                 }')
               echo "Brevo email sent. Response: $response"
             fi
@@ -64,4 +76,3 @@ jobs:
           else
             echo "notify-connector job succeeded."
           fi
-


### PR DESCRIPTION
Fix #89 

Test in GitHub action after publishing (or republishing) a page

This implementation uses a 3rd party email handler to send an email when the publish action triggers and its status is _failure_

- No Test URL
https://main--volvotrucks-us--volvogroup.aem.page/

### Note
unpublished, not implemented yet