### PR TITLE
FR: Adapting Press Releases to Use Pagination from Article Cards

### DIFF
--- a/blocks/press-releases/press-releases.js
+++ b/blocks/press-releases/press-releases.js
@@ -130,9 +130,14 @@ export default async function decorate(block) {
     }
     const baseURL = window.location.origin;
     await loadCSS(`${baseURL}/common/pagination/pagination.css`);
-    createPagination(chunkedPressReleases, block, 
-      isFeatured? createFeaturedPressReleaseList : isLatest ? createLatestPressReleases : createAllPressReleases,
-      contentArea, 0);
+    createPagination(
+      chunkedPressReleases,
+      block,
+      // eslint-disable-next-line no-nested-ternary
+      isFeatured ? createFeaturedPressReleaseList : isLatest ? createLatestPressReleases : createAllPressReleases,
+      contentArea,
+      0,
+    );
   } else {
     console.error('No chunked items created.');
   }

--- a/common/pagination/pagination.css
+++ b/common/pagination/pagination.css
@@ -64,6 +64,10 @@
   color: var(--c-main-black);
 }
 
+.pagination-arrow .icon {
+  display: flex;
+}
+
 .pagination-arrow .icon svg {
     fill: currentcolor;
     height: 1em;

--- a/common/pagination/pagination.css
+++ b/common/pagination/pagination.css
@@ -64,6 +64,12 @@
   color: var(--c-main-black);
 }
 
+.pagination-arrow .icon svg {
+    fill: currentcolor;
+    height: 1em;
+    width: 1em;
+}
+
 .pagination-arrow.prev {
   margin-right: 11px;
 }


### PR DESCRIPTION
Fix #43 

URL for testing:
- Before: https://main--volvotrucks-us--volvogroup.aem.page/news-and-stories/press-releases/
- After: https://43-press-releases-pagination--volvotrucks-us--volvogroup.aem.page/news-and-stories/press-releases/
