### PR TITLE
Bug: V2 Media with Text - Ensure consistent play/pause/mute button styling and correct video aspect ratio. #204

### DIFF
--- a/blocks/v2-media-with-text/v2-media-with-text.css
+++ b/blocks/v2-media-with-text/v2-media-with-text.css
@@ -30,28 +30,6 @@
   width: 100%;
 }
 
-/* Video with poster  */
-.v2-media-with-text--video-with-poster .v2-media-with-text__media {
-  aspect-ratio: 1;
-}
-
-.v2-media-with-text--video-with-poster .icon-play-video {
-  display: flex;
-}
-
-.v2-media-with-text--video-with-poster .v2-video__playback-button {
-  width: 100%;
-  height: 100%;
-  inset: 0;
-  transform: none;
-}
-
-.v2-media-with-text--video-with-poster .v2-video__playback-button .icon,
-.v2-media-with-text--video-with-poster .v2-video__playback-button .icon svg {
-  width: 72px;
-  height: 72px;
-}
-
 .v2-media-with-text__content-section,
 .v2-media-with-text__sub-text-section {
   width: 100%;
@@ -221,11 +199,6 @@
   /* Variant: default  */
   .v2-media-with-text__media-section .v2-media-with-text__media {
     aspect-ratio: 4/3;
-  }
-
-  /* Variant: video with poster  */
-  .v2-media-with-text--video-with-poster .v2-media-with-text__media {
-    aspect-ratio: 1;
   }
 
   /* Variant: media-left, media-right  */

--- a/blocks/v2-media-with-text/v2-media-with-text.css
+++ b/blocks/v2-media-with-text/v2-media-with-text.css
@@ -26,8 +26,10 @@
 }
 
 /* Video  */
-.v2-media-with-text__media-section video.v2-media-with-text__media {
+.v2-media-with-text__media-section video.v2-media-with-text__media,
+.v2-media-with-text__media-section .v2-media-with-text__media:has(.video-js) {
   width: 100%;
+  aspect-ratio: 16/9;
 }
 
 .v2-media-with-text__content-section,
@@ -71,7 +73,6 @@
 
 .v2-media-with-text--full-width .v2-media-with-text__media-section .v2-media-with-text__media {
   width: 100%;
-  aspect-ratio: 16/9;
   border-radius: 0;
 }
 


### PR DESCRIPTION
# Fixed
Buttons are set consistently, and all video players are 16/9 aspect ratio.

#
Fix #204

URL for testing:
- Before: https://main--volvotrucks-us--volvogroup.aem.page/block-library/blocks/v2-media-with-text
- After: https://204-video-buttons-consistent--volvotrucks-us--volvogroup.aem.page/block-library/blocks/v2-media-with-text

Library URL:
- Before: https://main--volvotrucks-us--volvogroup.aem.page/tools/sidekick/library.html?plugin=blocks&path=/block-library/blocks/v2-media-with-text&index=10
- After: https://204-video-buttons-consistent--volvotrucks-us--volvogroup.aem.page/tools/sidekick/library.html?plugin=blocks&path=/block-library/blocks/v2-media-with-text&index=10

Other markets:

Canada:
- Before: https://main--volvotrucks-ca--volvogroup.aem.page/block-library/blocks/v2-media-with-text
- After: https://204-video-buttons-consistent--volvotrucks-ca--volvogroup.aem.page/block-library/blocks/v2-media-with-text

Mexico:
- Before: https://main--volvotrucks-mx--volvogroup.aem.page/block-library/blocks/v2-media-with-text
- After: https://204-video-buttons-consistent--volvotrucks-mx--volvogroup.aem.page/block-library/blocks/v2-media-with-text
