### PR TITLE
NFR: FE WORK - implement press releases from query to opensearch #389

### DIFF
--- a/blocks/magazine-articles/magazine-articles.js
+++ b/blocks/magazine-articles/magazine-articles.js
@@ -61,6 +61,8 @@ const processMagazineArticles = async (params = {}) => {
 
   const articles = items.map((item) => parseArticleData(item));
 
+  // TODO: fix this since it wont bring all articles if count > 100
+  // OpenSearch limit is 100 items. See press.releases.service.js
   if (!params.limit && articles.length < count) {
     const moreArticles = await processMagazineArticles({
       ...params,

--- a/blocks/press-releases/press-releases.css
+++ b/blocks/press-releases/press-releases.css
@@ -1,115 +1,67 @@
-.block.press-releases article img {
+.press-releases__article img {
   display: block;
   width: 100%;
   aspect-ratio: 16 / 9;
   object-fit: cover;
-  margin-bottom: 1em;
+  margin-bottom: 16px;
 }
 
-.block.press-releases article p {
-  margin-top: unset;
+.press-releases__article p {
   margin-bottom: 8px;
-  font-size: 1.3rem;
+  font-size: var(--body-font-size-xxs);
 }
 
-.block.press-releases article span.date {
-  line-height: 2.1rem;
-  font-size: 1.4rem;
+.press-releases__article span.date {
+  font-size: var(--body-font-size-xs);
+  line-height: 20px;
   color: var(--volvo-text-light-gray);
 }
 
-.block.press-releases article h3 {
-  font-size: 2.4rem;
-  line-height: 3.2rem;
-  margin-top: 0.5em;
-  margin-bottom: 0.75em;
+.press-releases__article h3 {
+  margin: 12px 0 18px;
 }
 
-.block.press-releases article h3 a {
-  color: var(--volvo-text-gray);
+.press-releases__search-bar {
+  display: flex;
+  margin-bottom: 48px;
 }
 
-.block.press-releases p.button-container a {
-  background-color: unset;
-  color: var(--volvo-text-gray);
-  border-radius: 0;
-  border: 2px solid var(--volvo-text-gray);
-}
-
-.block.press-releases p.button-container {
-  text-align: center;
-  margin-top: 3em;
-  margin-bottom: 3em;
-}
-
-.block.press-releases p.button-container a:hover {
-  background-color: var(--c-grey-1);
-}
-
-.block.press-releases .list-filter input,
-.block.press-releases .list-filter select {
-  font-family: var(--ff-volvo-novum);
-  font-size: 1.6rem;
-}
-
-.block.press-releases .list-filter fieldset {
-  border: 0;
-}
-
-.block.press-releases .search-field {
-  display: grid;
-  grid-template-columns: 1fr 2.5em;
-  height: 54px;
-}
-
-.block.press-releases .search-field input {
-  width: 100%;
-  padding: 15px;
-  max-width: unset;
-  border: 0;
+.press-releases__search-bar input {
+  font-size: 1.8rem;
   margin-bottom: unset;
-  background-color: var(--input-background-color);
+  max-width: unset;
+  height: 64px;
+  padding: 15px 30px;
+  border: 1px solid transparent;
+  background-color: var(--background-light-gray);
 }
 
-.block.press-releases .search-field button {
+.press-releases__search-bar input::placeholder {
+  text-transform: uppercase;
+  opacity: 0.5;
+}
+
+.press-releases__search-bar input:hover {
+  outline-offset: -2px;
+}
+
+.press-releases__search-bar input:focus {
+  box-shadow: none;
+  outline: 0;
+}
+
+.press-releases__search-bar button {
   background-color: var(--c-cta-blue-default);
   color: var(--c-white);
   border: 0;
+  font-size: 16px;
+  min-width: 64px;
 }
 
-.block.press-releases .tags-field {
-  display: grid;
-  position: relative;
-  grid-template-columns: 1fr 68%;
-  align-items: center;
-  margin-bottom: 0.75em;
-}
-
-.block.press-releases .tags-field::after {
-  font-family: var(--ff-fontawesome);
-  color: var(--c-white);
-  content: '\f107';
-  position: absolute;
-  display: inline-block;
-  right: 20px;
-  top: 50%;
-  margin-top: -1.2rem;
-  line-height: 2.4rem;
-  font-size: 2.4rem;
-  pointer-events: none;
-}
-
-.block.press-releases .tags-field label {
-  font-size: 1.4rem;
-  justify-self: center;
-}
-
-.block.press-releases .tags-field select {
-  width: 100%;
-  appearance: none;
-  background-color: var(--c-cta-blue-default);
-  color: var(--c-white);
-  padding: 15px 40px 15px 15px;
+.press-releases__no-results-message {
+  font-size: var(--body-font-size-m);
+  text-align: center;
+  text-transform: uppercase;
 }
 
 .block.press-releases .article-list {
@@ -123,55 +75,10 @@
   border-top: 1px solid var(--background-light-gray);
 }
 
-.block.press-releases.cards {
-  margin-top: 2.18em;
-  margin-bottom: 2.18em;
-}
-
-.block.press-releases.cards span.date {
-  line-height: 1.4rem;
-  font-size: 1.6rem;
-  margin-top: 16px;
-  margin-bottom: 8px;
-  color: var(--volvo-text-light-gray);
-}
-
 @media screen and (min-width: 744px) {
-  .block.press-releases .list-filter fieldset {
-    display: flex;
-    justify-content: flex-start;
-    gap: 30px;
-    padding: 0;
-    margin: 0 0 48px;
-  }
-
-  .block.press-releases .list-filter fieldset > div {
-    flex: 0 0 33.3334%;
-  }
-
-  .block.press-releases .tags-field label {
-    justify-self: right;
-    padding-right: 8px;
-  }
-
   .block.press-releases .article-list article {
     display: grid;
     grid-template-columns: 25% calc(75% - 30px);
     gap: 30px;
-  }
-
-  .block.press-releases.cards .article-list {
-    display: flex;
-    column-gap: 30px;
-  }
-
-  .block.press-releases.cards .article-list li {
-    flex: 0 1 33.3334%;
-  }
-
-  .block.press-releases.cards .article-list article {
-    display: block;
-    padding: 0;
-    border-top: 0;
   }
 }

--- a/blocks/press-releases/press-releases.css
+++ b/blocks/press-releases/press-releases.css
@@ -27,7 +27,7 @@
 }
 
 .press-releases__search-bar input {
-  font-size: 1.8rem;
+  font-size: var(--body-font-size-xs);
   margin-bottom: unset;
   max-width: unset;
   height: 64px;
@@ -37,7 +37,6 @@
 }
 
 .press-releases__search-bar input::placeholder {
-  text-transform: uppercase;
   opacity: 0.5;
 }
 

--- a/blocks/press-releases/press-releases.css
+++ b/blocks/press-releases/press-releases.css
@@ -59,7 +59,7 @@
 .block.press-releases .search-field {
   display: grid;
   grid-template-columns: 1fr 2.5em;
-  margin-bottom: 0.75em;
+  height: 54px;
 }
 
 .block.press-releases .search-field input {
@@ -139,8 +139,10 @@
 @media screen and (min-width: 744px) {
   .block.press-releases .list-filter fieldset {
     display: flex;
-    justify-content: center;
+    justify-content: flex-start;
     gap: 30px;
+    padding: 0;
+    margin: 0 0 48px;
   }
 
   .block.press-releases .list-filter fieldset > div {

--- a/blocks/press-releases/press-releases.js
+++ b/blocks/press-releases/press-releases.js
@@ -7,6 +7,7 @@ const blockName = 'press-releases';
 let offsetMultiplier = 1;
 let temporaryOffset = 0;
 let isFirstLoad = true;
+const displayLimitAmount = 10;
 
 const parsePressRelease = (item) => {
   const isImageLink = (link) => `${link}`.split('?')[0].match(/\.(jpeg|jpg|gif|png|svg|bmp|webp)$/) !== null;
@@ -140,29 +141,20 @@ const loadChunkedArticles = async (block, pressReleases, displayLimitAmount) => 
   }
 };
 
-export default async function decorate(block) {
-  block.append(buildSearchBar());
-
-  const contentArea = createElement('div', { classes: ['pagination-content'] });
-  block.appendChild(contentArea);
-
-  const displayLimitAmount = 10;
-  let pressReleases = await getPressReleases();
-
-  loadChunkedArticles(block, pressReleases, displayLimitAmount);
-
+const addEventListeners = (block) => {
   const searchInput = block.querySelector(`.${blockName}__search-bar input`);
   const searchButton = block.querySelector(`.${blockName}__search-bar button`);
+  const contentArea = block.querySelector('.pagination-content');
 
   searchButton.addEventListener('click', async () => {
     const query = searchInput.value;
 
-    pressReleases = await getPressReleases(query);
+    const pressReleases = await getPressReleases(query);
     loadChunkedArticles(block, pressReleases, displayLimitAmount);
 
     if (pressReleases.length === 0) {
-      block.querySelector('.pagination-nav').innerHTML = '';
       contentArea.innerHTML = '';
+      block.querySelector('.pagination-nav').innerHTML = '';
       const noResultsMsg = createElement('p', { classes: `${blockName}__no-results-message` });
       noResultsMsg.textContent = getTextLabel('no results').replace('$0', `"${query}"`);
       contentArea.append(noResultsMsg);
@@ -174,4 +166,16 @@ export default async function decorate(block) {
       searchButton.click();
     }
   });
+};
+
+export default async function decorate(block) {
+  block.append(buildSearchBar());
+
+  const contentArea = createElement('div', { classes: ['pagination-content'] });
+  block.appendChild(contentArea);
+
+  const pressReleases = await getPressReleases();
+
+  loadChunkedArticles(block, pressReleases, displayLimitAmount);
+  addEventListeners(block);
 }

--- a/blocks/press-releases/press-releases.js
+++ b/blocks/press-releases/press-releases.js
@@ -75,7 +75,7 @@ const buildSearchBar = () => {
   const searchBar = createElement('div', { classes: `${blockName}__search-bar` });
   searchBar.innerHTML = `
     <input type="text" name="search" autocomplete="off" placeholder="${getTextLabel('PressReleases:SearchPlaceholder')}"/>
-    <button><i class="fa fa-search"></i></button>`;
+    <button type="submit"><i class="fa fa-search"></i></button>`;
   return searchBar;
 };
 

--- a/blocks/press-releases/press-releases.js
+++ b/blocks/press-releases/press-releases.js
@@ -4,7 +4,7 @@ import createPagination from '../../common/pagination/pagination.js';
 import { fetchPressReleases } from '../../scripts/services/press-release.service.js';
 
 const blockName = 'press-releases';
-let passes = 1;
+let offsetMultiplier = 1;
 let temporaryOffset = 0;
 let isFirstLoad = true;
 
@@ -41,8 +41,8 @@ const processPressReleases = async (params = {}) => {
   }
 
   const pressReleases = items.map((item) => parsePressRelease(item));
-  temporaryOffset = temporaryOffset + 100 < count ? 100 * passes : count - temporaryOffset + temporaryOffset;
-  passes++;
+  temporaryOffset = temporaryOffset + 100 < count ? 100 * offsetMultiplier : count - temporaryOffset + temporaryOffset;
+  offsetMultiplier++;
 
   if (temporaryOffset < count) {
     const morePressReleases = await processPressReleases({
@@ -57,7 +57,7 @@ const processPressReleases = async (params = {}) => {
 
 const getPressReleases = (query) => {
   if (!isFirstLoad) {
-    passes = 1;
+    offsetMultiplier = 1;
     temporaryOffset = 0;
   }
 

--- a/blocks/press-releases/press-releases.js
+++ b/blocks/press-releases/press-releases.js
@@ -1,4 +1,4 @@
-import { createElement, getOrigin, getDateFromTimestamp } from '../../scripts/common.js';
+import { createElement, getOrigin, getDateFromTimestamp, getTextLabel } from '../../scripts/common.js';
 import { createList, splitTags } from '../../scripts/magazine-press.js';
 import { createOptimizedPicture, loadCSS } from '../../scripts/aem.js';
 import createPagination from '../../common/pagination/pagination.js';
@@ -28,14 +28,8 @@ function filterPressReleases(pressReleases, activeFilters) {
 }
 
 function createFilter(pressReleases, activeFilters, createDropdown, createFullText) {
-  const tags = Array.from(new Set(pressReleases.flatMap((n) => n.filterTag).sort()));
-  const fullText = createFullText('search', activeFilters.search, 'type here to search');
-  const tagFilter = createDropdown(tags, activeFilters.tags, 'tags', 'All', 'filter by tags');
-  const tagSelection = tagFilter.querySelector('select');
-  tagSelection.addEventListener('change', (e) => {
-    e.target.form.submit();
-  });
-  return [fullText, tagFilter];
+  const fullText = createFullText('search', activeFilters.search, getTextLabel('PressReleases:SearchPlaceholder'));
+  return [fullText];
 }
 
 const parsePressRelease = (item) => {

--- a/placeholder.json
+++ b/placeholder.json
@@ -418,6 +418,10 @@
     {
       "Key": "charts:subtitle",
       "Text": "Engine Ratings"
+    },
+    {
+      "Key": "PressReleases:SearchPlaceholder",
+      "Text": "Type here to search"
     }
   ],
   ":type": "sheet"

--- a/placeholder.json
+++ b/placeholder.json
@@ -421,7 +421,7 @@
     },
     {
       "Key": "PressReleases:SearchPlaceholder",
-      "Text": "Type here to search"
+      "Text": "Search for..."
     }
   ],
   ":type": "sheet"

--- a/scripts/search-api.js
+++ b/scripts/search-api.js
@@ -154,3 +154,25 @@ export const topicSearchQuery = () => `
     }
   }
 `;
+
+export const pressReleaseQuery = () => `
+ query Edssearch($tenant: String!, $language: EdsLocaleEnum!, $q: String, $limit: Int, $offset: Int,
+  $facets: [EdsFieldEnum], $sort: EdsSortOptionsEnum, $article: ArticleFilter, $category: [String]) {
+    edssearch(tenant: $tenant, language: $language, q: $q, limit: $limit, offset: $offset,
+    facets: $facets, sort: $sort, article: $article, category: $category) {
+      count
+      items {
+        uuid
+        metadata {
+          title
+          description
+          image
+          url
+          language
+          category
+          publishDate
+        }
+      }
+    }
+  } 
+`;

--- a/scripts/services/press-release.service.js
+++ b/scripts/services/press-release.service.js
@@ -1,0 +1,86 @@
+import { getLocale } from '../common.js';
+import { fetchSearchData, pressReleaseQuery, TENANT } from '../search-api.js';
+
+/**
+ * Sorts an array of articles by a specified date field within the `metadata` object.
+ * @param {Array<Object>} articles - The array of article objects to be sorted.
+ * Each article must have a `metadata` property.
+ * @param {string} dateField - The name of the date field within the `metadata` object to sort by
+ * (e.g., "lastModified" or "publishDate").
+ * @returns {Array<Object>} A new array of articles sorted in descending order by the specified
+ * date field. Articles with invalid or missing date fields are excluded from the result.
+ */
+export const sortArticlesByDateField = (articles, dateField) => {
+  const articlesWithTimestamps = articles.map((article) => {
+    const rawTimestamp = article.metadata?.[dateField];
+    const timestamp = rawTimestamp ? new Date(rawTimestamp * 1000).getTime() : null;
+
+    if (timestamp === null) {
+      console.warn(`Date field "${dateField}" not found or invalid in metadata for article`, article);
+    }
+
+    return {
+      ...article,
+      timestamp,
+    };
+  });
+
+  const sortedArticles = articlesWithTimestamps.filter((article) => article.timestamp !== null).sort((a, b) => b.timestamp - a.timestamp);
+
+  return sortedArticles;
+};
+
+/**
+ * Fetches magazine articles based on the provided criteria.
+ *
+ * @param {Object} options - Options for fetching magazine articles.
+ * @param {number} options.limit - The maximum number of articles to fetch.
+ * @param {number} [options.offset=0] - The starting point for fetching articles (pagination).
+ * @param {Object|null} [options.tags=null] - An object with keys "truck", "topic" and/or "category" to filter articles, or null.
+ * @param {string} [options.q='truck'] - The query term to search for articles.
+ * @param {string} [options.sort] - The sorting criteria for articles.
+ * @param {string} [options.tenant=TENANT] - The tenant identifier.
+ * @param {string} [options.language=getLocale().split('-')[0].toUpperCase()] -
+ * The language code for the articles.
+ * @param {string} [options.category='magazine'] - The category of articles to fetch.
+ * @param {Array<string>} [options.facets=['ARTICLE', 'TOPIC', 'TRUCK']] -
+ * The facets to include in the search.
+ * @returns {Promise<Object|null>} The fetched articles data, or null if an error occurs.
+ *
+ * @async
+ * @throws {Error} Logs errors to the console and returns null if the fetch fails.
+ */
+export const fetchPressReleases = async ({
+  tenant = TENANT,
+  language = getLocale().split('-')[0].toUpperCase(),
+  q = 'Press releases',
+  limit = 100,
+  offset = 0,
+  category = 'Press releases',
+  sort,
+} = {}) => {
+  const variables = {
+    tenant,
+    language,
+    q,
+    limit,
+    offset,
+    category,
+    sort,
+  };
+
+  try {
+    if (!tenant) {
+      throw new Error('TENANT not defined');
+    }
+
+    const rawData = await fetchSearchData({
+      query: pressReleaseQuery(),
+      variables,
+    });
+    return rawData?.data?.edssearch || null;
+  } catch (error) {
+    console.error('Error fetching magazine articles:', error);
+    return null;
+  }
+};

--- a/scripts/services/press-release.service.js
+++ b/scripts/services/press-release.service.js
@@ -24,7 +24,7 @@ import { fetchSearchData, pressReleaseQuery, TENANT } from '../search-api.js';
 export const fetchPressReleases = async ({
   tenant = TENANT,
   language = getLocale().split('-')[0].toUpperCase(),
-  q = 'Press releases',
+  q = 'Volvo',
   limit = 100,
   offset = 0,
   category = 'Press releases',

--- a/scripts/services/press-release.service.js
+++ b/scripts/services/press-release.service.js
@@ -2,35 +2,6 @@ import { getLocale } from '../common.js';
 import { fetchSearchData, pressReleaseQuery, TENANT } from '../search-api.js';
 
 /**
- * Sorts an array of articles by a specified date field within the `metadata` object.
- * @param {Array<Object>} articles - The array of article objects to be sorted.
- * Each article must have a `metadata` property.
- * @param {string} dateField - The name of the date field within the `metadata` object to sort by
- * (e.g., "lastModified" or "publishDate").
- * @returns {Array<Object>} A new array of articles sorted in descending order by the specified
- * date field. Articles with invalid or missing date fields are excluded from the result.
- */
-export const sortArticlesByDateField = (articles, dateField) => {
-  const articlesWithTimestamps = articles.map((article) => {
-    const rawTimestamp = article.metadata?.[dateField];
-    const timestamp = rawTimestamp ? new Date(rawTimestamp * 1000).getTime() : null;
-
-    if (timestamp === null) {
-      console.warn(`Date field "${dateField}" not found or invalid in metadata for article`, article);
-    }
-
-    return {
-      ...article,
-      timestamp,
-    };
-  });
-
-  const sortedArticles = articlesWithTimestamps.filter((article) => article.timestamp !== null).sort((a, b) => b.timestamp - a.timestamp);
-
-  return sortedArticles;
-};
-
-/**
  * Fetches magazine articles based on the provided criteria.
  *
  * @param {Object} options - Options for fetching magazine articles.


### PR DESCRIPTION
Fix #389

URL for testing:
- Before: https://main--volvotrucks-us--volvogroup.aem.page/
- After: https://389-press-releases--volvotrucks-us--volvogroup.aem.page/

Other markets:

Canada FR-CA:
- Before: https://main--volvotrucks-ca--volvogroup.aem.page/fr-ca/
- After: https://389-press-releases--volvotrucks-ca--volvogroup.aem.page/fr-ca/

Canada EN-CA:
- Before: https://main--volvotrucks-ca--volvogroup.aem.page/
- After: https://389-press-releases--volvotrucks-ca--volvogroup.aem.page/

