### PR TITLE
Bug: MyTruck App Padding from Connectivity section

### DIFF
--- a/common/modal/modal.css
+++ b/common/modal/modal.css
@@ -353,6 +353,11 @@ body:has(.modal--reveal[aria-hidden='false']) :where(._hj-widget-container, .ot-
   }
 }
 
+.modal-content > .v2-media-with-text-container:nth-child(3) {
+  padding-block: 0;
+  margin-block: 56px 80px;
+}
+
 .modal-content .v2-text .v2-text__title {
   margin-bottom: 8px;
 }


### PR DESCRIPTION
Fix #335 

URL for testing:
- Before: https://main--volvotrucks-us--volvogroup.aem.page/trucks/all-new-vnr/#connectivity
- After: https://335-fix-spacing-in-connectivity--volvotrucks-us--volvogroup.aem.page/trucks/all-new-vnr/#connectivity

Note: It is tricky one so I applied the spacing only to content of modal. If you think there is better approach to fix this issue, do let me know.