### PR TITLE
FR: Extend limit of articles in magazine query #438

### DIFF
--- a/blocks/magazine-articles/magazine-articles.css
+++ b/blocks/magazine-articles/magazine-articles.css
@@ -271,6 +271,12 @@
   .block.magazine-articles .truck-field::after {
     top: 15px;
   }
+
+  /* make sure the fields have the same width when stacked */
+  .block.magazine-articles .list-filter fieldset div:nth-of-type(odd),
+  .block.magazine-articles .list-filter fieldset div:nth-of-type(even) {
+    width: calc(50% - 30px);
+  }
 }
 
 @media screen and (min-width: 992px) {
@@ -306,20 +312,12 @@
   .block.magazine-articles .article-list article .content {
     padding-left: 15px;
   }
-
-  /* make sure the fields have the same width when stacked */
-  .block.magazine-articles .list-filter fieldset div:nth-of-type(odd) {
-    min-width: 396px;
-  }
-
-  .block.magazine-articles .list-filter fieldset div:nth-of-type(even) {
-    min-width: 341px;
-  }
 }
 
 @media screen and (min-width: 1300px) {
   .block.magazine-articles .list-filter fieldset div:nth-of-type(odd),
   .block.magazine-articles .list-filter fieldset div:nth-of-type(even) {
     min-width: unset;
+    max-width: calc(25% - 30px);
   }
 }

--- a/blocks/magazine-articles/magazine-articles.css
+++ b/blocks/magazine-articles/magazine-articles.css
@@ -155,6 +155,7 @@
   height: 100%;
   width: 100%;
   object-fit: cover;
+  aspect-ratio: 16 / 9;
 }
 
 .block.magazine-articles article picture.default-image img {

--- a/blocks/v2-article-cards/v2-article-cards.css
+++ b/blocks/v2-article-cards/v2-article-cards.css
@@ -35,6 +35,10 @@
   height: 14px;
 }
 
+.v2-article-cards__article-card:hover {
+  text-decoration: none; 
+}
+
 .v2-article-cards__article-card:hover .v2-article-cards__card-button a {
   text-decoration: underline;
 }

--- a/blocks/v2-article-cards/v2-article-cards.js
+++ b/blocks/v2-article-cards/v2-article-cards.js
@@ -211,7 +211,7 @@ export default async function decorate(block) {
   }
 
   const uniqueArticles = await filterDisplayedArticles(articles);
-  // After sorting articles by date, set the chunks of the array for future pagination
+  // After checking for repeated articles, set the chunks of the array for future pagination
   const chunkedArticles = uniqueArticles?.reduce((resultArray, item, index) => {
     limitAmount = limitAmount || 9;
     const chunkIndex = Math.floor(index / limitAmount);

--- a/scripts/magazine-press.js
+++ b/scripts/magazine-press.js
@@ -60,7 +60,7 @@ function createDropdown(options, selected, name, placeholder, label) {
   if (options) {
     options.forEach((option) => {
       const optionTag = createElement('option', {
-        props: { value: toClassName(option) },
+        props: { value: option },
       });
       optionTag.innerText = option;
       if (optionTag.value === selected) {

--- a/scripts/services/magazine.service.js
+++ b/scripts/services/magazine.service.js
@@ -168,6 +168,7 @@ export const fetchMagazineArticles = async ({
     sort,
     article: tags,
   };
+
   try {
     if (!tenant) {
       throw new Error('TENANT not defined');

--- a/scripts/services/magazine.service.js
+++ b/scripts/services/magazine.service.js
@@ -168,7 +168,6 @@ export const fetchMagazineArticles = async ({
     sort,
     article: tags,
   };
-
   try {
     if (!tenant) {
       throw new Error('TENANT not defined');


### PR DESCRIPTION
Fix #438

URL for testing:
### `magazine articles` block + latest (3 articles):
- Before: https://main--volvotrucks-us--volvogroup.aem.page/news-and-stories/
- After: https://438-mgz-query--volvotrucks-us--volvogroup.aem.page/news-and-stories/

### `magazine articles` block (all articles & filters):
- Before: https://main--volvotrucks-us--volvogroup.aem.page/drafts/shomps/magazine-articles
- After: https://438-mgz-query--volvotrucks-us--volvogroup.aem.page/drafts/shomps/magazine-articles

### `v2 article cards` block + latest (3 articles):
- Before: https://main--volvotrucks-us--volvogroup.aem.page/news-and-stories/volvo-trucks-stories/
- After: https://438-mgz-query--volvotrucks-us--volvogroup.aem.page/news-and-stories/volvo-trucks-stories/

### `v2 article cards` block variants:
*0 FEATURED*
- Before: https://main--volvotrucks-us--volvogroup.aem.page/drafts/shomps/article-cards/0-featured
- After: https://438-mgz-query--volvotrucks-us--volvogroup.aem.page/drafts/shomps/article-cards/0-featured

*1 FEATURED*
- Before: https://main--volvotrucks-us--volvogroup.aem.page/drafts/shomps/article-cards/1-featured
- After: https://438-mgz-query--volvotrucks-us--volvogroup.aem.page/drafts/shomps/article-cards/1-featured

*2 FEATURED*
- Before: https://main--volvotrucks-us--volvogroup.aem.page/drafts/shomps/article-cards/2-featured
- After: https://438-mgz-query--volvotrucks-us--volvogroup.aem.page/drafts/shomps/article-cards/2-featured

*3 FEATURED*
- Before: https://main--volvotrucks-us--volvogroup.aem.page/drafts/shomps/article-cards/3-featured
- After: https://438-mgz-query--volvotrucks-us--volvogroup.aem.page/drafts/shomps/article-cards/3-featured

