### PR TITLE
Bug: Delay in loading of header on homepage #452

### DIFF
--- a/scripts/common.js
+++ b/scripts/common.js
@@ -1,4 +1,4 @@
-import { loadCSS, loadBlock, loadSections, loadHeader, buildBlock, decorateBlock, getMetadata } from './aem.js';
+import { loadCSS, loadBlock, loadSections, buildBlock, decorateBlock, getMetadata } from './aem.js';
 
 let placeholders = null;
 
@@ -225,12 +225,7 @@ export async function loadLazy(doc) {
   }
   const header = doc.querySelector('header');
 
-  const disableHeader = getMetadata('disable-header').toLowerCase() === 'true';
   const disableFooter = getMetadata('disable-footer').toLowerCase() === 'true';
-
-  if (!disableHeader) {
-    loadHeader(header);
-  }
 
   if (!disableFooter) {
     loadFooter(doc.querySelector('footer'));

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -11,6 +11,7 @@ import {
   loadCSS,
   loadScript,
   loadBlock,
+  loadHeader,
 } from './aem.js';
 
 import {
@@ -800,8 +801,15 @@ export function decorateMain(main, head) {
 async function loadEager(doc) {
   decorateTemplateAndTheme();
 
+  const disableHeader = getMetadata('disable-header').toLowerCase() === 'true';
   const main = doc.querySelector('main');
   const { head } = doc;
+
+  if (!disableHeader) {
+    const header = doc.querySelector('header');
+    header && loadHeader(header);
+  }
+
   if (main) {
     decorateMain(main, head);
     document.body.classList.add('appear');


### PR DESCRIPTION
# Fixed

Changed the loading from the `loadLazy` function to the `loadEager` one. Now, loads just at the beginning without any waiting.

#
### Fix #452

URL for testing:
- Before: https://main--volvotrucks-us--volvogroup.aem.page/
- After: https://452-header-loading-delay--volvotrucks-us--volvogroup.aem.page/

Disabled header:
- Before: https://main--volvotrucks-us--volvogroup.aem.page/trucks/vnr/truck-builder/
- After: https://452-header-loading-delay--volvotrucks-us--volvogroup.aem.page/trucks/vnr/truck-builder/

Other markets:

Canada:
- Before: https://main--volvotrucks-ca--volvogroup.aem.page/
- After: https://452-header-loading-delay--volvotrucks-ca--volvogroup.aem.page/

Mexico:
- Before: https://main--volvotrucks-mx--volvogroup.aem.page/
- After: https://452-header-loading-delay--volvotrucks-mx--volvogroup.aem.page/
