### PR TITLE
FR: Secondary CTA for Fleet Owners landing page #467

### DIFF
--- a/blocks/v2-hero/v2-hero.css
+++ b/blocks/v2-hero/v2-hero.css
@@ -239,6 +239,10 @@
 
 /* END - Countdown  */
 
+.bottom-sticky-cta .v2-hero__buttons-wrapper {
+  align-items: baseline;
+}
+
 @media (min-width: 744px) {
   .v2-hero {
     --v2-hero-padding: 50px;

--- a/blocks/v2-inpage-navigation/v2-inpage-navigation.css
+++ b/blocks/v2-inpage-navigation/v2-inpage-navigation.css
@@ -1,12 +1,12 @@
 :root {
   --inpage-navigation-height: 58px;
+  --inpage-navigation-bottom-height: 116px;
+  --inpage-navigation-factor: var(--inpage-navigation-bottom-height);
 }
 
 .v2-inpage-navigation-wrapper {
   background-color: var(--c-white);
-  height: auto !important;
   left: 0;
-  overflow: unset !important;
   position: sticky;
   top: var(--nav-height);
   width: 100%;
@@ -193,10 +193,66 @@ then we change it for the next section item in main */
   line-height: var(--f-button-line-height);
 }
 
+.bottom-sticky-cta .v2-inpage-navigation-wrapper {
+  top: calc(100% - var(--inpage-navigation-bottom-height) + var(--inpage-navigation-factor));
+  height: 0;
+}
+
+.bottom-sticky-cta .v2-inpage-navigation {
+  background-color: var(--c-white);
+  height: var(--inpage-navigation-bottom-height);
+}
+
+.bottom-sticky-cta .v2-inpage-navigation__wrapper {
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
+  flex-direction: column;
+}
+
+.bottom-sticky-cta .v2-inpage-navigation__marketing {
+  width: 100%;
+}
+
+.bottom-sticky-cta .marketing.v2-inpage-navigation__marketing.v2-inpage-navigation__marketing--secondary {
+  background-color: var(--c-white);
+  color: var(--c-main-black);
+  border-color: var(--c-main-black);
+}
+
+.bottom-sticky-cta .marketing.v2-inpage-navigation__marketing.v2-inpage-navigation__marketing--secondary:hover {
+  background-color: var(--c-grey-50);
+  border-color: var(--c-grey-400);
+}
+
+@media (min-width: 450px) {
+  :root {
+    --inpage-navigation-bottom-height: var(--inpage-navigation-height);
+    --inpage-navigation-factor: var(--inpage-navigation-height);
+  }
+
+  .bottom-sticky-cta .v2-inpage-navigation__wrapper {
+    flex-direction: row;
+  }
+
+  .bottom-sticky-cta .v2-inpage-navigation__marketing {
+    width: auto;
+  }
+}
+
 @media (min-width: 744px) {
   .v2-inpage-navigation__wrapper {
     padding-left: 32px;
     padding-right: 32px;
+  }
+
+  .bottom-sticky-cta .v2-inpage-navigation-wrapper {
+    top: var(--nav-height);
+    height: auto;
+  }
+
+  .bottom-sticky-cta .v2-inpage-navigation__wrapper {
+    justify-content: flex-end;
   }
 }
 

--- a/blocks/v2-inpage-navigation/v2-inpage-navigation.js
+++ b/blocks/v2-inpage-navigation/v2-inpage-navigation.js
@@ -22,11 +22,15 @@ const scrollToSection = (id) => {
   resizeObserver.observe(main);
 };
 
-const inpageNavigationButton = () => {
-  // if we have a button title & button link
-  if (getMetadata('inpage-button') && getMetadata('inpage-link')) {
-    const title = getMetadata('inpage-button');
-    const url = getMetadata('inpage-link');
+/**
+ * Creates an in-page navigation button element if both button title and link are provided.
+ *
+ * @param {string} title - The title of the button.
+ * @param {string} url - The URL the button should link to.
+ * @returns {HTMLElement|null} The anchor element representing the button, or null if required parameters are missing.
+ */
+const createInPageButton = (title, url, secondary = false) => {
+  if (title && url) {
     const link = createElement('a', {
       classes: ['button', 'marketing', `${blockName}__marketing`],
       props: {
@@ -34,12 +38,41 @@ const inpageNavigationButton = () => {
         title,
       },
     });
+    if (secondary) {
+      link.classList.add(`${blockName}__marketing--secondary`);
+    }
     link.textContent = title;
 
     return link;
   }
-
   return null;
+};
+
+/**
+ * Creates an in-page navigation button element if both button title and link metadata are available.
+ *
+ * @returns {HTMLElement|null} The anchor element representing the button, or null if required metadata is missing.
+ */
+const inPageNavigationButton = () => {
+  // if we have a button title & button link
+  const title = getMetadata('inpage-button');
+  const url = getMetadata('inpage-link');
+  return createInPageButton(title, url);
+};
+
+/**
+ * Creates an array of in-page navigation buttons based on metadata.
+ * Each item in the returned array can be an HTMLElement or null, depending on the presence of metadata.
+ *
+ * @returns {(HTMLElement|null)[]} An array containing up to two elements: each is either an HTMLElement or null.
+ */
+const inPageNavigationButtons = () => {
+  // if we have primary and secondary inpage buttons
+  const primaryButton = getMetadata('inpage-primary-button');
+  const primaryLink = getMetadata('inpage-primary-link');
+  const secondaryButton = getMetadata('inpage-secondary-button');
+  const secondaryLink = getMetadata('inpage-secondary-link');
+  return [createInPageButton(primaryButton, primaryLink), createInPageButton(secondaryButton, secondaryLink, true)];
 };
 
 // Retrieve an array of sections with its corresponding intersectionRatio
@@ -107,7 +140,7 @@ const updateActive = (id) => {
   }
 };
 
-const addHeaderScrollBehaviour = (header) => {
+const addHeaderScrollBehavior = (header) => {
   let prevPosition = 0;
 
   window.addEventListener('scroll', () => {
@@ -122,8 +155,44 @@ const addHeaderScrollBehaviour = (header) => {
   });
 };
 
-export default async function decorate(block) {
-  const ctaButton = inpageNavigationButton();
+/**
+ * Update the in-page navigation factor based on the visibility of the CTA button.
+ * @param {HTMLElement} ctaButton
+ */
+const updateNavFactor = (ctaButton = null) => {
+  if (!ctaButton) {
+    return;
+  }
+  const rect = ctaButton.getBoundingClientRect();
+  const docStyle = getComputedStyle(document.documentElement);
+  const navHeight = parseFloat(docStyle.getPropertyValue('--inpage-navigation-bottom-height')) || 0;
+
+  // Calculate visible height of CTA button within viewport
+  const visible = Math.max(0, Math.min(rect.bottom, window.innerHeight) - Math.max(rect.top, 0));
+  const factor = rect.height > 0 ? Math.max(0, Math.min(navHeight, (visible / rect.height) * navHeight)) : navHeight;
+
+  document.documentElement.style.setProperty('--inpage-navigation-factor', `${factor}px`);
+};
+
+/**
+ * Add scroll behavior to the bottom sticky CTA.
+ */
+const addBottomScrollBehavior = () => {
+  const primaryButton = getMetadata('inpage-primary-button');
+  const primaryCta = document.querySelector(`.v2-hero a[title="${primaryButton}"]:not(.${blockName}__marketing`);
+  const secondaryButton = getMetadata('inpage-secondary-button');
+  const secondaryCta = document.querySelector(`a[title="${secondaryButton}"]:not(.${blockName}__marketing)`);
+  const ctaButton = secondaryCta || primaryCta;
+
+  window.addEventListener('scroll', () => updateNavFactor(ctaButton), { passive: true });
+};
+
+/**
+ * Decorate a single button within the in-page navigation.
+ * @param {HTMLElement} block
+ */
+const decorateSingleButton = (block) => {
+  const ctaButton = inPageNavigationButton();
 
   const wrapper = block.querySelector(':scope > div');
   wrapper.classList.add(`${blockName}__wrapper`);
@@ -138,8 +207,8 @@ export default async function decorate(block) {
   const dropdownTitle = createElement('span', { classes: `${blockName}__dropdown-title` });
 
   const sectionTitle = createElement('span', { classes: `${blockName}__title` });
-  const inpageTitle = getMetadata('inpage-title');
-  sectionTitle.innerText = inpageTitle;
+  const inPageTitle = getMetadata('inpage-title');
+  sectionTitle.innerText = inPageTitle;
 
   const listCloseButton = createElement('button', { classes: `${blockName}__items-close` });
   const closeIcon = createElement('span', { classes: ['icon', 'icon-close'] });
@@ -248,5 +317,47 @@ export default async function decorate(block) {
     }),
   );
 
-  addHeaderScrollBehaviour(block.parentNode);
+  addHeaderScrollBehavior(block.parentNode);
+};
+
+/**
+ * Decorate the two buttons within the in-page navigation.
+ * @param {HTMLElement} block
+ */
+const decorateTwoButtons = (block) => {
+  const isLargerThanMobile = window.matchMedia('(min-width: 744px)').matches;
+  const [primaryButton, secondaryButton] = inPageNavigationButtons();
+  const wrapper = createElement('div', { classes: `${blockName}__wrapper` });
+  block.innerText = '';
+
+  if (primaryButton) {
+    wrapper.appendChild(primaryButton);
+  }
+
+  if (secondaryButton) {
+    wrapper.appendChild(secondaryButton);
+  }
+
+  if (primaryButton || secondaryButton) {
+    block.appendChild(wrapper);
+  }
+
+  if (isLargerThanMobile) {
+    addHeaderScrollBehavior(block.parentNode);
+    return;
+  }
+
+  addBottomScrollBehavior();
+};
+
+export default async function decorate(block) {
+  // Check if the block is within a bottom sticky CTA variant set in metadata
+  const isBottomSticky = block.closest('main')?.classList.contains('bottom-sticky-cta');
+
+  if (isBottomSticky) {
+    decorateTwoButtons(block);
+    return;
+  }
+
+  decorateSingleButton(block);
 }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -637,10 +637,6 @@ function buildInpageNavigationBlock(main) {
 
   if (items.length > 0) {
     const section = createElement('div');
-    Object.assign(section.style, {
-      height: '48px',
-      overflow: 'hidden',
-    });
     const inpageBlock = buildBlock(inpageClassName, { elems: items });
 
     section.append(inpageBlock);


### PR DESCRIPTION
# Update

To set up this feature, a new variant needs to be added in the metadata block:
- Style: _bottom-sticky-cta_

Instead of the regular inpage-button it uses the primary and secondary versions:
- _Inpage-primary-button_ with a text to set in the button
- _inpage-primary-link_ to set the link
same but with secondary
- _Inpage-secondary-button_
- _inpage-secondary-link_

To follow the AC and the design, in mobile view, small enough to fit the buttons at the bottom, are set vertically, but from 450px width until tablet view, the buttons are set in a row.

If the user scrolls and the second button in the hero goes up out of view, the bottom buttons appear from the bottom, and the other way around if the button appears from the top.

In tablet and desktop viewports, the sticky behaviour remains.

The second button, to go to the form, the link has to be set by the content.

#
Fix #467

URL for testing:
- Before: https://main--volvotrucks-us--volvogroup.aem.page/drafts/jlledo/campaign/v2-sticky-cta
- After: https://467-sticky-bottom-cta--volvotrucks-us--volvogroup.aem.page/drafts/jlledo/campaign/v2-sticky-cta

Other examples without the new variant:
- Before: https://main--volvotrucks-us--volvogroup.aem.page/trucks/vnl/
- After: https://467-sticky-bottom-cta--volvotrucks-us--volvogroup.aem.page/trucks/vnl/

- Before: https://main--volvotrucks-us--volvogroup.aem.page/trucks/all-new-vnr/
- After: https://467-sticky-bottom-cta--volvotrucks-us--volvogroup.aem.page/trucks/all-new-vnr/


Other markets:

Canada:
- Before: https://main--volvotrucks-ca--volvogroup.aem.page/
- After: https://467-sticky-bottom-cta--volvotrucks-ca--volvogroup.aem.page/

Mexico:
- Before: https://main--volvotrucks-mx--volvogroup.aem.page/
- After: https://467-sticky-bottom-cta--volvotrucks-mx--volvogroup.aem.page/
