### PR TITLE
FR: New variant for the V2 Content Card block #470

### DIFF
--- a/blocks/v2-content-card/v2-content-card.css
+++ b/blocks/v2-content-card/v2-content-card.css
@@ -140,13 +140,14 @@
 }
 
 .v2-content-card--with-button .v2-content-card__content {
-  gap: 24px;
+  gap: 16px;
+  justify-content: space-between;
 }
 
 .v2-content-card--with-button .v2-content-card__title {
-    font-size: var(--f-heading-3-font-size);
-    line-height: var(--f-heading-3-line-height);
-    letter-spacing: var(--f-heading-3-letter-spacing);
+    font-size: var(--f-heading-4-font-size);
+    line-height: var(--f-heading-4-line-height);
+    letter-spacing: var(--f-heading-4-letter-spacing);
 }
 
 @media screen and (min-width: 744px) {
@@ -275,5 +276,15 @@
     font-size: var(--f-body-2-font-size);
     letter-spacing: var(--f-body-2-letter-spacing);
     line-height: var(--f-body-2-line-height);
+  }
+
+  .v2-content-card--with-button .v2-content-card__content {
+    gap: 24px;
+  }
+
+  .v2-content-card--with-button .v2-content-card__title {
+      font-size: var(--f-heading-3-font-size);
+      line-height: var(--f-heading-3-line-height);
+      letter-spacing: var(--f-heading-3-letter-spacing);
   }
 }

--- a/blocks/v2-content-card/v2-content-card.css
+++ b/blocks/v2-content-card/v2-content-card.css
@@ -139,6 +139,16 @@
   background-color: var(--c-grey-200);
 }
 
+.v2-content-card--with-button .v2-content-card__content {
+  gap: 24px;
+}
+
+.v2-content-card--with-button .v2-content-card__title {
+    font-size: var(--f-heading-3-font-size);
+    line-height: var(--f-heading-3-line-height);
+    letter-spacing: var(--f-heading-3-letter-spacing);
+}
+
 @media screen and (min-width: 744px) {
   :root {
     --v2-content-card-container-margin: 0px;

--- a/blocks/v2-content-card/v2-content-card.css
+++ b/blocks/v2-content-card/v2-content-card.css
@@ -139,6 +139,10 @@
   background-color: var(--c-grey-200);
 }
 
+.v2-content-card--with-button {
+  flex-wrap: nowrap;
+}
+
 .v2-content-card--with-button .v2-content-card__content {
   gap: 16px;
   justify-content: space-between;

--- a/blocks/v2-content-card/v2-content-card.js
+++ b/blocks/v2-content-card/v2-content-card.js
@@ -3,7 +3,7 @@ import { adjustPretitle, createElement, removeEmptyTags, variantsClassesToBEM } 
 import { createVideo, getDynamicVideoHeight, isVideoLink } from '../../scripts/video-helper.js';
 
 const blockName = 'v2-content-card';
-const variantClasses = ['images-grid', 'images-grid-masonry', 'editorial'];
+const variantClasses = ['images-grid', 'images-grid-masonry', 'editorial', 'with-button'];
 
 const handleVideoLinks = (videoLinks) => {
   videoLinks.forEach((videoLink) => {


### PR DESCRIPTION
Fix #470 

URL for testing:
- Before: https://main--volvotrucks-us--volvogroup.aem.page/drafts/naga/v2-content-card
- After: https://470-v2-content-card-new-variant--volvotrucks-us--volvogroup.aem.page/drafts/naga/v2-content-card

Block Library:
- Before: https://main--volvotrucks-us--volvogroup.aem.page/tools/sidekick/library.html?plugin=blocks&path=/block-library/blocks/v2-content-card&index=2
- After: https://470-v2-content-card-new-variant--volvotrucks-us--volvogroup.aem.page/tools/sidekick/library.html?plugin=blocks&path=/block-library/blocks/v2-content-card&index=7

Please use variant `(with-button)` to test this in V2 content card component.  Also use link with bold styling in document to have a button in the page.

