### PR TITLE
FR: Update V2 Truck Lineup block #473

### DIFF
--- a/blocks/v2-truck-lineup/v2-truck-lineup.css
+++ b/blocks/v2-truck-lineup/v2-truck-lineup.css
@@ -312,6 +312,11 @@ ul.v2-truck-lineup__color-switcher {
 
 .truck-lineup-buttons .v2-truck-lineup__navigation-item.active button {
   color: var(--button-primary-color);
+  background-color: var(--button-primary-bg);
+}
+
+.truck-lineup-buttons .v2-truck-lineup__navigation-item.active button:hover {
+  background-color: var(--button-primary-bg-active);
 }
 
 @media screen and (min-width: 744px) {

--- a/blocks/v2-truck-lineup/v2-truck-lineup.css
+++ b/blocks/v2-truck-lineup/v2-truck-lineup.css
@@ -188,6 +188,15 @@ ul.v2-truck-lineup__navigation {
   text-transform: uppercase;
 }
 
+ .truck-lineup-buttons .v2-truck-lineup__navigation {
+  gap: 8px;
+  padding: 0;
+}
+
+.truck-lineup-buttons .v2-truck-lineup__navigation-item {
+  margin: 0;
+}
+
 ul.v2-truck-lineup__color-switcher {
   display: flex;
   justify-content: center;
@@ -291,10 +300,18 @@ ul.v2-truck-lineup__color-switcher {
   outline-offset: 1px;
 }
 
+.truck-lineup-buttons .v2-truck-lineup__navigation-item button {
+  width: max-content;
+}
+
 .v2-truck-lineup__arrow-controls button:focus-visible,
 .v2-truck-lineup__arrow-controls:focus-within button,
 .v2-truck-lineup__slider-wrapper:hover .v2-truck-lineup__arrow-controls button {
   opacity: 1;
+}
+
+.truck-lineup-buttons .v2-truck-lineup__navigation-item.active button {
+  color: var(--button-primary-color);
 }
 
 @media screen and (min-width: 744px) {


### PR DESCRIPTION
# Update

In this update, the truck lineup has a new variant set in the metadata as a new _style_ because this is an autoblock and can't have a variants set as a regular block.

The variant is called `truck-lineup-buttons`

I also added the current default variant as a reference in the second pair of links

#
Fix #473

URL for testing:
- Before: https://main--volvotrucks-us--volvogroup.aem.page/drafts/jlledo/v2-truck-lineup-buttons
- After: https://473-update-truck-lineup--volvotrucks-us--volvogroup.aem.page/drafts/jlledo/v2-truck-lineup-buttons

Current TAB version
- Before: https://main--volvotrucks-us--volvogroup.aem.page/
- After: https://473-update-truck-lineup--volvotrucks-us--volvogroup.aem.page/

