### PR TITLE
Bug: Large text size for Content Carousel #507

### DIFF
--- a/blocks/v2-content-carousel/v2-content-carousel.css
+++ b/blocks/v2-content-carousel/v2-content-carousel.css
@@ -311,7 +311,6 @@ ul.v2-content-carousel__arrowcontrols {
   }
 
   .v2-content-carousel.interactive .v2-content-carousel__figure-text {
-    font-size: var(--f-heading-3-font-size);
     padding: 40px;
   }
 


### PR DESCRIPTION
Fix #507

URL for testing:
- Before: https://main--volvotrucks-us--volvogroup.aem.page/campaign/vnl/
- After: https://507-bug-carousel--volvotrucks-us--volvogroup.aem.page/campaign/vnl/

Library:
- Before: https://main--volvotrucks-us--volvogroup.aem.page/tools/sidekick/library.html?theme=light&plugin=blocks&path=/block-library/blocks/v2-content-carousel&index=3
- After: https://507-bug-carousel--volvotrucks-us--volvogroup.aem.page/tools/sidekick/library.html?theme=light&plugin=blocks&path=/block-library/blocks/v2-content-carousel&index=3

Other markets:

Canada:
- Before: https://main--volvotrucks-ca--volvogroup.aem.page/
- After: https://507-bug-carousel--volvotrucks-ca--volvogroup.aem.page/

Mexico:
- Before: https://main--volvotrucks-mx--volvogroup.aem.page/
- After: https://507-bug-carousel--volvotrucks-mx--volvogroup.aem.page/
