### PR TITLE
 Transport Canada: Rename "Issue Date" to "NHTSA Issue Date“ [Volvo-English] #493

### DIFF
--- a/placeholder.json
+++ b/placeholder.json
@@ -101,7 +101,7 @@
     },
     {
       "Key": "recall_date",
-      "Text": "Issue Date"
+      "Text": "NHTSA Issue Date"
     },
     {
       "Key": "tc_recall_date",


### PR DESCRIPTION
Fix #493

URL for testing:
- Before: https://main--volvotrucks-us--volvogroup.aem.page/
- After: https://493-nhtsa-name--volvotrucks-us--volvogroup.aem.page/
