### PR TITLE
Release 47

### DIFF
--- a/blocks/v2-hero/v2-hero.css
+++ b/blocks/v2-hero/v2-hero.css
@@ -194,6 +194,10 @@
   min-height: fit-content;
 }
 
+.v2-hero--marketing video + .v2-hero__content-wrapper {
+  background: none;
+}
+
 /* Scroll icon */
 .v2-hero__scroll-icon {
   border-radius: 20px;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "volvotrucks-na",
-  "version": "46.0.0",
+  "version": "47.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "volvotrucks-na",
-      "version": "46.0.0",
+      "version": "47.0.0",
       "license": "UNLICENSED",
       "devDependencies": {
         "copyfiles": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "volvotrucks-na",
   "private": true,
-  "version": "46.0.0",
+  "version": "47.0.0",
   "description": "Volvo Trucks North America",
   "engines": {
     "node": ">=v20.15.1 <23",


### PR DESCRIPTION
Fix #<gh-issue-id>

URL for testing:
- Before: https://main--volvotrucks-us--volvogroup.aem.page/
- After: https://release-47--volvotrucks-us--volvogroup.aem.page/

Other markets:

Canada:
- Before: https://main--volvotrucks-ca--volvogroup.aem.page/
- After: https://release-47--volvotrucks-ca--volvogroup.aem.page/

Mexico:
- Before: https://main--volvotrucks-mx--volvogroup.aem.page/
- After: https://release-47--volvotrucks-mx--volvogroup.aem.page/
